### PR TITLE
Issue/md5sum

### DIFF
--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -238,6 +238,9 @@ class OpenFOAMCase(BlockMesh):
         self._exec_operation([solver])
 
     def is_file_modified(self, path: str) -> bool:
+        """
+        checks if a file has been modified by comparing the current md5sum with the previously saved one inside `self.job.dict`
+        """
         if "md5sum" not in self.job.doc["obr"]:
             return False  # no md5sum has been calculated for this file
         current_md5sum = self.job.doc["obr"]["md5sum"].get(path)
@@ -245,6 +248,9 @@ class OpenFOAMCase(BlockMesh):
         return current_md5sum != md5sum
 
     def is_tree_modified(self) -> list[str]:
+        """
+        iterates all files inside the case tree and returns a list of files that were modified, based on their md5sum.
+        """
         m_files = []
         for file in self.config_file_tree:
             if self.is_file_modified(file):
@@ -252,6 +258,9 @@ class OpenFOAMCase(BlockMesh):
         return m_files
 
     def perform_post_md5sum_calculations(self):
+        """
+        calculates md5sums for all case files. Primarily called from `dispatch_post_hooks`
+        """
         for case_path in self.config_file_tree:
             case_file = Path(self.job.path) / "case" / case_path
             md5sum = check_output(["md5sum", case_file], text=True)

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -15,13 +15,12 @@ from .BlockMesh import BlockMesh, calculate_simple_partition
 
 from Owls.parser.FoamDict import FileParser
 
-# FIXME extend regex for other OPENFOAM variants
 OF_HEADER_REGEX = r"""(/\*--------------------------------\*- C\+\+ -\*----------------------------------\*\\
-\| =========                 \|                                                 \|
-\| \\\\      /  F ield         \| OpenFOAM: The Open Source CFD Toolbox           \|
-\|  \\\\    /   O peration     \| Version:  v\d{4}                                 \|
-\|   \\\\  /    A nd           \| Web:      www\.OpenFOAM\.com                      \|
-\|    \\\\/     M anipulation  \|                                                 \|
+(\||)\s*=========                 \|(\s*\||)
+(\||)\s*\\\\      /  F ield         \| (OpenFOAM:|foam-extend:)\s*[\d\w\W]*\s*(\||)
+(\||)\s*\\\\    /   O peration     \| (Version:|Website:)\s*[\d\w\W]*\s*(\||)
+(\||)\s*\\\\  /    A nd           \| (Web:|Version:)\s*[\d\w\W]*\s*(\||)
+(\||)\s*\\\\/     M anipulation  \|(\s*\||)
 \\\*---------------------------------------------------------------------------\*/)"""
 
 

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -109,7 +109,7 @@ class OpenFOAMCase(BlockMesh):
         return self.path / "constant"
 
     @property
-    def constant_polyMesh_folder(self):
+    def const_polyMesh_folder(self):
         cpf = self.constant_folder / "polyMesh"
         if cpf.exists():
             return cpf
@@ -172,9 +172,7 @@ class OpenFOAMCase(BlockMesh):
             self.file_dict[rel_path] = file
         for file, rel_path in self.config_files_in_folder(self.system_include_folder):
             self.file_dict[rel_path] = file
-        for file, rel_path in self.config_files_in_folder(
-            self.constant_polyMesh_folder
-        ):
+        for file, rel_path in self.config_files_in_folder(self.const_polyMesh_folder):
             self.file_dict[rel_path] = file
         return list(self.file_dict.keys())
 

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -44,6 +44,12 @@ class File(FileParser):
             self._md5sum = check_output(["md5sum", str(self.path)], text=True)
         return self._md5sum
 
+    def is_modified(self) -> bool:
+        if not self._md5sum:
+            return False
+        current_md5sum = check_output(["md5sum", str(self.path)], text=True)
+        return self._md5sum != current_md5sum
+
     # @decorator_modifies_file
     def set(self, args: dict):
         """modifies the current controlDict by the given dictionary

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -16,7 +16,7 @@ OF_HEADER_REGEX = r"""(/\*--------------------------------\*- C\+\+ -\*---------
 (\||)\s*=========                 \|(\s*\||)
 (\||)\s*\\\\      /  F ield         \| (OpenFOAM:|foam-extend:)\s*[\d\w\W]*\s*(\||)
 (\||)\s*\\\\    /   O peration     \| (Version:|Website:)\s*[\d\w\W]*\s*(\||)
-(\||)\s*\\\\  /    A nd           \| (Web:|Version:)\s*[\d\w\W]*\s*(\||)
+(\||)\s*\\\\  /    A nd           \| (Web:|Version:|Website)\s*[\d\w\W]*\s*(\||)
 (\||)\s*\\\\/     M anipulation  \|(\s*\||)
 \\\*---------------------------------------------------------------------------\*/)"""
 
@@ -154,6 +154,9 @@ class OpenFOAMCase(BlockMesh):
         self, folder: Path
     ) -> Generator[Tuple[File, str], Any, None]:
         """Yields all OF config files  in given folder"""
+        if not folder:
+            # const_polymesh and system_include can be None
+            return
         if folder.is_dir():
             for f_path in folder.iterdir():
                 if f_path.is_file() and not f_path.is_symlink():

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -72,7 +72,6 @@ class OpenFOAMCase(BlockMesh):
     """A class for simple access to typical OpenFOAM files"""
 
     def __init__(self, path, job):
-        print(path)
         self.path_ = Path(path)
         self.job = job
         self.controlDict = File(folder=self.system_folder, file="controlDict", job=job)

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -72,11 +72,14 @@ class OpenFOAMCase(BlockMesh):
     """A class for simple access to typical OpenFOAM files"""
 
     def __init__(self, path, job):
+        print(path)
         self.path_ = Path(path)
         self.job = job
         self.controlDict = File(folder=self.system_folder, file="controlDict", job=job)
         self.fvSolution = File(folder=self.system_folder, file="fvSolution", job=job)
-        self.fvSchemes = File(folder=self.system_folder, file="fvSchemes", job=job)
+        # FIXME fvSchemes does not exist when using this class in post hooks?
+        if Path(self.system_folder / 'fvSchemes').exists():
+            self.fvSchemes = File(folder=self.system_folder, file="fvSchemes", job=job)
         self.decomposeParDict = File(
             folder=self.system_folder, file="decomposeParDict", job=job, optional=True
         )
@@ -92,6 +95,20 @@ class OpenFOAMCase(BlockMesh):
     @property
     def constant_folder(self):
         return self.path / "constant"
+
+    @property
+    def constant_polyMesh_folder(self):
+        cpf = self.constant_folder / 'polyMesh'
+        if cpf.exists():
+            return cpf
+        return None
+
+    @property
+    def system_include_folder(self):
+        cpf = self.system_folder / 'include'
+        if cpf.exists():
+            return cpf
+        return None
 
     @property
     def zero_folder(self):
@@ -120,6 +137,33 @@ class OpenFOAMCase(BlockMesh):
         _, folds, files = next(os.walk(self.path))
         proc_folds = [self.path / f for f in folds if "processor" in f]
         return proc_folds
+
+    @property
+    def config_file_tree(self) -> list[Path]:
+        "Iterates through case file tree and returns a list of paths to non-symlinked files."
+        files = []
+        if self.system_folder.is_dir():
+            for f in self.system_folder.iterdir():
+                f_path = self.system_folder / f
+                if f_path.is_file() and not f_path.is_symlink():
+                    files.append(f_path)
+        if self.system_include_folder is not None:
+            for f in self.system_include_folder.iterdir():
+                f_path = self.system_include_folder / f
+                if f_path.is_file() and not f_path.is_symlink():
+                    files.append(f_path)
+        if self.constant_folder.is_dir():
+            for f in self.constant_folder.iterdir():
+                f_path = self.constant_folder / f
+                if f_path.is_file() and not f_path.is_symlink():
+                    files.append(f_path)
+        if self.constant_polyMesh_folder is not None:
+            for f in self.constant_polyMesh_folder.iterdir():
+                f_path = self.constant_polyMesh_folder / f
+                if f_path.is_file() and not f_path.is_symlink():
+                    files.append(f_path)
+        return files
+
 
     def _exec_operation(self, operation):
         logged_execute(operation, self.path, self.job.doc)
@@ -168,3 +212,17 @@ class OpenFOAMCase(BlockMesh):
     def run(self, args: dict):
         solver = self.controlDict.get("application")
         self._exec_operation([solver])
+
+    def is_file_modified(self, path):
+        if 'md5sum' not in self.job.doc['obr']:
+            return False  # no md5sum has been calculated for this file
+        current_md5sum = self.job.doc['obr']['md5sum'].get(path)
+        md5sum = check_output(["md5sum", path], text=True)
+        return current_md5sum != md5sum
+
+    def is_tree_modified(self):
+        m_files = []
+        for file in self.config_file_tree:
+            if self.is_file_modified(file):
+                m_files.append(file)
+        return m_files

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -15,6 +15,7 @@ from .BlockMesh import BlockMesh, calculate_simple_partition
 
 from Owls.parser.FoamDict import FileParser
 
+# FIXME extend regex for other OPENFOAM variants
 OF_HEADER_REGEX = r"""(/\*--------------------------------\*- C\+\+ -\*----------------------------------\*\\
 \| =========                 \|                                                 \|
 \| \\\\      /  F ield         \| OpenFOAM: The Open Source CFD Toolbox           \|

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -4,7 +4,7 @@ import errno
 import os
 from pathlib import Path
 from subprocess import check_output
-
+import re
 from ..core.core import (
     logged_execute,
     logged_func,
@@ -15,13 +15,13 @@ from .BlockMesh import BlockMesh, calculate_simple_partition
 
 from Owls.parser.FoamDict import FileParser
 
-OF_HEADER = r"""/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  v2206                                 |
-|   \\  /    A nd           | Web:      www.OpenFOAM.com                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/"""
+OF_HEADER_REGEX = r"""(/\*--------------------------------\*- C\+\+ -\*----------------------------------\*\\
+\| =========                 \|                                                 \|
+\| \\\\      /  F ield         \| OpenFOAM: The Open Source CFD Toolbox           \|
+\|  \\\\    /   O peration     \| Version:  v\d{4}                                 \|
+\|   \\\\  /    A nd           \| Web:      www\.OpenFOAM\.com                      \|
+\|    \\\\/     M anipulation  \|                                                 \|
+\\\*---------------------------------------------------------------------------\*/)"""
 
 
 class File(FileParser):
@@ -189,7 +189,7 @@ class OpenFOAMCase(BlockMesh):
         with path.open() as f:
             try:
                 header = ''.join(f.readlines()[:7])
-                return header[:-1] == OF_HEADER   # ignore last \n
+                return re.match(OF_HEADER_REGEX, header) is not None
             except UnicodeDecodeError:
                 return False
 

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -241,7 +241,10 @@ class OpenFOAMCase(BlockMesh):
         """
         if "md5sum" not in self.job.doc["obr"]:
             return False  # no md5sum has been calculated for this file
-        current_md5sum = self.job.doc["obr"]["md5sum"].get(path)
+        current_md5sum, last_modified = self.job.doc["obr"]["md5sum"].get(path)
+        if os.path.getmtime(path) == last_modified:
+            # if modification dates dont differ, the md5sums wont, either
+            return False
         md5sum = check_output(["md5sum", path], text=True)
         return current_md5sum != md5sum
 
@@ -267,4 +270,5 @@ class OpenFOAMCase(BlockMesh):
             signac_friendly_path = path_to_key(
                 str(case_path)
             )  # signac does not allow . inside paths or job.doc keys
-            self.job.doc["obr"]["md5sum"][signac_friendly_path] = md5sum.split()[0]
+            last_modified = os.path.getmtime(case_file)
+            self.job.doc["obr"]["md5sum"][signac_friendly_path] = (md5sum.split()[0], last_modified)

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -6,9 +6,10 @@ import hashlib
 from pathlib import Path
 from subprocess import check_output
 from typing import Union
+
 # these are to be replaced with each other
-SIGNAC_PATH_TOKEN = '_dot_'
-PATH_TOKEN = '.'
+SIGNAC_PATH_TOKEN = "_dot_"
+PATH_TOKEN = "."
 
 
 def parse_variables_impl(in_str, args, domain):
@@ -24,8 +25,8 @@ def parse_variables(in_str):
 
 
 def path_to_key(path: Union[str, Path]) -> str:
-    """Signac throws errors if '.' are used in keys within JSONAttrDicts, which are often needed, for example in file names. 
-    Thus, this function replaces . with _dot_ """
+    """Signac throws errors if '.' are used in keys within JSONAttrDicts, which are often needed, for example in file names.
+    Thus, this function replaces . with _dot_"""
     return str(path).replace(PATH_TOKEN, SIGNAC_PATH_TOKEN)
 
 

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -6,6 +6,10 @@ import hashlib
 from pathlib import Path
 from subprocess import check_output
 
+# these are to be replaced with each other
+SIGNAC_PATH_TOKEN = '_dot_'
+PATH_TOKEN = '.'
+
 
 def parse_variables_impl(in_str, args, domain):
     ocurrances = re.findall(r"\${{" + domain + "\.(\w+)}}", in_str)
@@ -19,6 +23,16 @@ def parse_variables(in_str):
     return in_str
 
 
+def path_to_signac(path: str | Path) -> str:
+    """Signac throws errors if . are in e.g. file names. We replace . with """
+    return str(path).replace(PATH_TOKEN, SIGNAC_PATH_TOKEN)
+
+
+def signac_to_path(sign_path: str | Path) -> str:
+    """Counter function to `path_to_signac`, allowing equal transformations."""
+    return str(sign_path).replace(SIGNAC_PATH_TOKEN, PATH_TOKEN)
+
+
 def logged_execute(cmd, path, doc):
     """execute cmd and logs success
 
@@ -30,7 +44,7 @@ def logged_execute(cmd, path, doc):
     check_output(["mkdir", "-p", ".obr_store"], cwd=path)
     d = doc.get("obr", {})
     cmd_str = " ".join(cmd)
-    cmd_str = cmd_str.replace(".", "_dot_").split()
+    cmd_str = path_to_signac(cmd_str).split()  # replace dots in cmd_str with _dot_'s
     if len(cmd_str) > 1:
         flags = cmd_str[1:]
     else:

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -5,7 +5,7 @@ import re
 import hashlib
 from pathlib import Path
 from subprocess import check_output
-
+from typing import Union
 # these are to be replaced with each other
 SIGNAC_PATH_TOKEN = '_dot_'
 PATH_TOKEN = '.'
@@ -23,13 +23,14 @@ def parse_variables(in_str):
     return in_str
 
 
-def path_to_signac(path: str | Path) -> str:
-    """Signac throws errors if . are in e.g. file names. We replace . with """
+def path_to_key(path: Union[str, Path]) -> str:
+    """Signac throws errors if '.' are used in keys within JSONAttrDicts, which are often needed, for example in file names. 
+    Thus, this function replaces . with _dot_ """
     return str(path).replace(PATH_TOKEN, SIGNAC_PATH_TOKEN)
 
 
-def signac_to_path(sign_path: str | Path) -> str:
-    """Counter function to `path_to_signac`, allowing equal transformations."""
+def key_to_path(sign_path: Union[str, Path]) -> str:
+    """Counter function to `path_to_key`, allowing equal transformations."""
     return str(sign_path).replace(SIGNAC_PATH_TOKEN, PATH_TOKEN)
 
 
@@ -44,7 +45,7 @@ def logged_execute(cmd, path, doc):
     check_output(["mkdir", "-p", ".obr_store"], cwd=path)
     d = doc.get("obr", {})
     cmd_str = " ".join(cmd)
-    cmd_str = path_to_signac(cmd_str).split()  # replace dots in cmd_str with _dot_'s
+    cmd_str = path_to_key(cmd_str).split()  # replace dots in cmd_str with _dot_'s
     if len(cmd_str) > 1:
         flags = cmd_str[1:]
     else:

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -46,7 +46,8 @@ def is_case(job):
 
 
 def operation_complete(job, operation):
-    """An operation is considered to be complete if an entry in the job document with same arguments exists and state is success"""
+    """An operation is considered to be complete if an entry in the job document with same arguments exists and state is success
+    """
     if job.doc.get("state") == "ready":
         return True
     else:
@@ -107,7 +108,8 @@ def base_case_is_ready(job):
 
 
 def _link_path(base: Path, dst: Path, copy_instead_link: bool):
-    """creates file tree under dst with same folder structure as base but all files are relative symlinks"""
+    """creates file tree under dst with same folder structure as base but all files are relative symlinks
+    """
     # ensure dst path exists
     check_output(["mkdir", "-p", str(dst)])
 
@@ -261,7 +263,8 @@ def dispatch_pre_hooks(operation_name, job):
 
 
 def dispatch_post_hooks(operation_name, job):
-    """Forwards to `execute_post_build`, performs md5sum calculation of case files and finishes with `end_job_state`"""
+    """Forwards to `execute_post_build`, performs md5sum calculation of case files and finishes with `end_job_state`
+    """
     execute_post_build(operation_name, job)
     case = OpenFOAMCase(str(job.path) + "/case", job)
     case.perform_post_md5sum_calculations()
@@ -490,6 +493,7 @@ def get_values(jobs: list, key: str) -> set:
 )
 def runParallelSolver(job, args={}):
     from datetime import datetime
+
     skip_complete = os.environ.get("OBR_SKIP_COMPLETE")
     if skip_complete and finished(job):
         return "true"

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -267,18 +267,26 @@ def gather_caseFiles(case_path: str) -> list[str]:
     const_path = case_path + '/constant'
     const_polyMesh_path = const_path + '/polyMesh'
     files = []
-    for f in os.listdir(sys_path):
-        f_path = os.path.join(sys_path, f)
-        if os.path.isfile(f_path) and not os.path.islink(f_path):
-            files.append(f_path)
-    for f in os.listdir(sys_include_path):
-        f_path = os.path.join(sys_include_path, f)
-        if os.path.isfile(f_path) and not os.path.islink(f_path):
-            files.append(f_path)
-    for f in os.listdir(const_polyMesh_path):    # NOTE is polymesh subject to change during simulation?
-        f_path = os.path.join(const_polyMesh_path, f)
-        if os.path.isfile(f_path) and not os.path.islink(f_path):
-            files.append(f_path)
+    if os.path.isdir(sys_path):
+        for f in os.listdir(sys_path):
+            f_path = os.path.join(sys_path, f)
+            if os.path.isfile(f_path) and not os.path.islink(f_path):
+                files.append(f_path)
+    if os.path.isdir(sys_include_path):
+        for f in os.listdir(sys_include_path):
+            f_path = os.path.join(sys_include_path, f)
+            if os.path.isfile(f_path) and not os.path.islink(f_path):
+                files.append(f_path)
+    if os.path.isdir(const_path):
+        for f in os.listdir(const_path):
+            f_path = os.path.join(const_path, f)
+            if os.path.isfile(f_path) and not os.path.islink(f_path):
+                files.append(f_path)
+    if os.path.isdir(const_polyMesh_path):
+        for f in os.listdir(const_polyMesh_path):    # NOTE is polymesh subject to change during simulation?
+            f_path = os.path.join(const_polyMesh_path, f)
+            if os.path.isfile(f_path) and not os.path.islink(f_path):
+                files.append(f_path)
     return files
 
 
@@ -292,7 +300,7 @@ def dispatch_post_hooks(operation_name, job):
             job.doc['obr']['md5sum'] = dict()
         _, r_path = case_file.split(job.id)[:]  # NOTE is total path really necessary?
         f_path, fname = r_path.rsplit('/', 1)[:]
-        signac_friendly_path = f_path + fname.replace('.', '-')   # NOTE signac throws: "Mapping keys may not contain dots ('.')"
+        signac_friendly_path = f"{f_path}/{fname.replace('.', '-')}"   # NOTE signac throws: "Mapping keys may not contain dots ('.')"
         job.doc["obr"]["md5sum"][signac_friendly_path] = md5sum.split()[0]
     end_job_state(operation_name, job)
 

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -313,7 +313,6 @@ def set_failure(operation_name, error, job):
 @generate
 @OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
 @OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
-@OpenFOAMProject.operation_hooks.on_exit(dispatch_post_hooks)
 @OpenFOAMProject.operation_hooks.on_exception(set_failure)
 @OpenFOAMProject.pre(lambda job: basic_eligible(job, "controlDict"))
 @OpenFOAMProject.post(lambda job: operation_complete(job, "controlDict"))
@@ -462,7 +461,6 @@ def decomposePar(job, args={}):
 def fetchCase(job, args={}):
     args = get_args(job, args)
 
-    print('Running fetchCase')
     case_type = job.sp()["type"]
     fetch_case_handler = getattr(CaseOrigins, case_type)(args)
     fetch_case_handler.init(job=job)
@@ -529,7 +527,6 @@ def get_values(jobs: list, key: str) -> set:
 )
 def runParallelSolver(job, args={}):
     from datetime import datetime
-    print('running runParallelSolver')
     skip_complete = os.environ.get("OBR_SKIP_COMPLETE")
     if skip_complete and finished(job):
         return "true"

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -264,14 +264,13 @@ def dispatch_post_hooks(operation_name, job):
     """just forwards to start_job_state and execute_pre_build"""
     execute_post_build(operation_name, job)
     case = OpenFOAMCase(str(job.path) + "/case", job)
-    files = case.config_file_tree
+    files: list[str] = case.config_file_tree
     for case_path in files:
-        case_file = str(case_path)
+        case_file = Path(job.path) / 'case' / case_path
         md5sum = check_output(["md5sum", case_file], text=True)
         if 'md5sum' not in job.doc['obr']:
             job.doc['obr']['md5sum'] = dict()
-        rel_path = case_path.relative_to(job.path).parts[1:]
-        signac_friendly_path = path_to_signac(str(rel_path))  # signac does not allow . inside paths or job.doc keys
+        signac_friendly_path = path_to_signac(str(case_path))  # signac does not allow . inside paths or job.doc keys
         job.doc["obr"]["md5sum"][signac_friendly_path] = md5sum.split()[0]
     end_job_state(operation_name, job)
 

--- a/tests/test_md5sum.py
+++ b/tests/test_md5sum.py
@@ -59,8 +59,6 @@ def test_md5sum_calculation(tmpdir, emmit_test_config):
     with open(job_doc_path) as job_file:
         job = json.load(job_file)
         md5summed_files_actual = [file.rsplit('/', 1)[1].replace('-', '.') for file in job['obr']['md5sum']]
-        print(md5summed_files_target)
-        print(md5summed_files_actual)
         for fname in md5summed_files_actual:
             if fname in md5summed_files_target:
                 md5summed_files_target.remove(fname)

--- a/tests/test_md5sum.py
+++ b/tests/test_md5sum.py
@@ -1,0 +1,67 @@
+from obr.create_tree import create_tree
+from obr.signac_wrapper.operations import OpenFOAMProject, gather_caseFiles
+
+import pytest
+import os
+import json
+
+
+@pytest.fixture
+def emmit_test_config():
+    return {
+        "case": {
+            "type": "GitRepo",
+            "solver": "pisoFoam",
+            "url": "https://develop.openfoam.com/committees/hpc.git",
+            "folder": "Lid_driven_cavity-3d/S",
+            "commit": "f9594d16aa6993bb3690ec47b2ca624b37ea40cd",
+            "cache_folder": "None/S",
+            "post_build": [
+                {"shell": "cp system/fvSolution.fixedNORM system/fvSolution"},
+                {"controlDict": {"writeFormat": "binary", "libs": ["libOGL.so"]}},
+                {
+                    "fvSolution": {
+                        "set": "solvers/p",
+                        "clear": True,
+                        "tolerance": "1e-04",
+                        "relTol": 0,
+                        "maxIter": 3000,
+                    }
+                },
+            ],
+        },
+    }
+
+
+def test_md5sum_calculation(tmpdir, emmit_test_config):
+    project = OpenFOAMProject.init_project(root=tmpdir)
+
+    create_tree(
+        project, emmit_test_config, {"folder": tmpdir}, skip_foam_src_check=True
+    )
+
+    workspace_dir = tmpdir / "workspace"
+
+    assert workspace_dir.exists()
+
+    root, folder, files = next(os.walk(workspace_dir))
+
+    assert len(folder) == 1
+    for fold in folder:
+        case_fold = workspace_dir / fold
+        assert case_fold.exists()
+    project.run(names=["fetchCase"])
+
+    case_path = os.path.join(root, folder[0], 'case')
+    md5summed_files_target = set([f.rsplit('/', 1)[1] for f in gather_caseFiles(case_path=case_path)])
+    job_doc_path = os.path.join(root, folder[0], 'signac_job_document.json')
+
+    with open(job_doc_path) as job_file:
+        job = json.load(job_file)
+        md5summed_files_actual = [file.rsplit('/', 1)[1].replace('-', '.') for file in job['obr']['md5sum']]
+        print(md5summed_files_target)
+        print(md5summed_files_actual)
+        for fname in md5summed_files_actual:
+            if fname in md5summed_files_target:
+                md5summed_files_target.remove(fname)
+    assert len(md5summed_files_target) == 0


### PR DESCRIPTION
Implements #47 .

Added functionality includes calculation of md5sums of files inside a `case` directory that are not symbolic links.
`gather_caseFiles`, as the name suggests, traverses a given `case` directory and returns a list of paths to aforementioned files.
As specified in the issue, the md5sums thereof are saved to `job.doc['obr']['md5sum'][$FILE]`.

Like I already commented in #47 , signac does not like dots inside `job.doc` keys. My current approach is to replace the dots with dashes, however, I am open for more stable solutions. 

Slight input on my side is needed to finish up this PR ( see the NOTE's in `operations.py`).
