### PR TITLE
fix openFOAMCase test suites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "PyYAML",
     "signac==1.8.0",
     "signac-flow==0.23.0",
+    "GitPython==3.1.31",
     "Owls @ git+https://github.com/greole/Owls.git@Owls2.0"
 ]
 

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -90,9 +90,11 @@ class OpenFOAMCase(BlockMesh):
         # FIXME fvSchemes does not exist when using this class in post hooks?
         if Path(self.system_folder / "fvSchemes").exists():
             self.fvSchemes = File(folder=self.system_folder, file="fvSchemes", job=job)
-        self.decomposeParDict = File(
-            folder=self.system_folder, file="decomposeParDict", job=job, optional=True
-        )
+        # decomposeParDict might not exist in some test cases
+        if Path(self.system_folder / "decomposeParDict").exists():
+            self.decomposeParDict = File(
+                folder=self.system_folder, file="decomposeParDict", job=job, optional=True
+            )
         self.file_dict: dict[str, File] = dict()
         self.config_file_tree
 

--- a/tests/test_OpenFOAMCase.py
+++ b/tests/test_OpenFOAMCase.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 import shutil
 from subprocess import check_output
+from git.repo import Repo
 
 
 @pytest.fixture
@@ -20,24 +21,15 @@ def set_up_of_case(tmpdir):
         shutil.copytree(src, dst)
         return dst
 
-    check_output(
-        [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            "--filter=blob:none",
-            "--sparse",
-            "https://github.com/OpenFOAM/OpenFOAM-10.git",
-        ],
-        cwd=tmpdir,
-    )
+    url = "https://github.com/OpenFOAM/OpenFOAM-10.git"
+    Repo.clone_from(url=url, to_path=tmpdir, multi_options=['--depth 1'])
 
-    of_dir = tmpdir / "OpenFOAM-10"
+    of_dir = Path(tmpdir)
 
     check_output(["git", "sparse-checkout", "set", "tutorials"], cwd=of_dir)
 
-    return of_dir / "tutorials" / lid_driven_cavity
+    rval = of_dir / "tutorials" / lid_driven_cavity
+    return rval
 
 
 def test_OpenFOAMCaseProperties(set_up_of_case):
@@ -81,4 +73,4 @@ def test_OpenFOAMCaseSetter(set_up_of_case):
     of_case.controlDict.set({"startTime": 10})
     assert of_case.controlDict.get("startTime") == 10
 
-    assert of_case.is_decomposed == False
+    assert of_case.is_decomposed is False

--- a/tests/test_OpenFOAMCase.py
+++ b/tests/test_OpenFOAMCase.py
@@ -21,12 +21,15 @@ def set_up_of_case(tmpdir):
         shutil.copytree(src, dst)
         return dst
 
-    url = "https://github.com/OpenFOAM/OpenFOAM-10.git"
-    Repo.clone_from(url=url, to_path=tmpdir, multi_options=['--depth 1'])
+    of_dir = Path('~/OpenFOAM/OpenFOAM-10')
+    if of_dir.exists():
+        shutil.copytree(of_dir, tmpdir)
+    else:
+        of_dir = Path(tmpdir)
+        url = "https://github.com/OpenFOAM/OpenFOAM-10.git"
+        Repo.clone_from(url=url, to_path=tmpdir, multi_options=['--depth 1'])
 
-    of_dir = Path(tmpdir)
 
-    check_output(["git", "sparse-checkout", "set", "tutorials"], cwd=of_dir)
 
     rval = of_dir / "tutorials" / lid_driven_cavity
     return rval


### PR DESCRIPTION
Fixes #75.
More precisely, This fixes the errors inside the pytest fixture. 

Also, I added a `Path.exists()` check to the `OpenFOAMCase.__init__` method for the `decomposeParDict` property.