### PR TITLE
List operations

### DIFF
--- a/docs/source/commandLine/CLI.md
+++ b/docs/source/commandLine/CLI.md
@@ -12,3 +12,5 @@
 ```
 ```{include} submit.md
 ```
+```{include} operations.md
+```

--- a/docs/source/commandLine/init.md
+++ b/docs/source/commandLine/init.md
@@ -13,3 +13,5 @@ Options:
   --verbose INTEGER      set verbosity
   --help                 Show this message and exit.
 ```
+
+Make sure to have openfoam sourced. 

--- a/docs/source/commandLine/init.md
+++ b/docs/source/commandLine/init.md
@@ -13,5 +13,3 @@ Options:
   --verbose INTEGER      set verbosity
   --help                 Show this message and exit.
 ```
-
-Make sure to have openfoam sourced. 

--- a/docs/source/commandLine/operations.md
+++ b/docs/source/commandLine/operations.md
@@ -1,0 +1,12 @@
+## OBR operations
+
+`obr operations` lists all available operations inside a given `OpenFOAMProject`.
+
+### Usage
+```zsh
+Usage: obr operations [OPTIONS]
+
+Options:
+  -f, --folder TEXT
+  --help             Show this message and exit.
+```

--- a/docs/source/commandLine/run.md
+++ b/docs/source/commandLine/run.md
@@ -10,7 +10,9 @@ Options:
   -f, --folder TEXT
   -o, --operations TEXT  Specify the operation(s) to run. Pass multiple
                          operations after -o, separated by commata (NO space),
-                         e.g. obr run -o shell,apply.  [required]
+                         e.g. obr run -o shell,apply. Run with --help to list
+                         available operations.  [required]
+  -l, --list-operations  Prints all available operations and returns.
   -j, --job TEXT
   --args TEXT
   -t, --tasks INTEGER
@@ -29,4 +31,4 @@ A set of operations can be passed after the `-o` flag.
 It is important to note, that there can be no whitespace in between. Otherwise, 
 the `runParallelSolver` will be parsed as separate commandline argument.
 
-To list all available operations, run `obr run --list-operations` or [`obr operations`](#obr-operations).
+To list all available operations, run `obr run --list-operations`, `obr run [--operations|-o] --help` or [`obr operations`](#obr-operations).

--- a/docs/source/commandLine/run.md
+++ b/docs/source/commandLine/run.md
@@ -29,16 +29,4 @@ A set of operations can be passed after the `-o` flag.
 It is important to note, that there can be no whitespace in between. Otherwise, 
 the `runParallelSolver` will be parsed as separate commandline argument.
 
-Currently, the viable operations are as follows:
-- apply
-- archive, 
-- blockMesh
-- checkMesh 
-- controlDict, 
-- decomposePar
-- fetchCase
-- fvSolution
-- refineMesh 
-- runParallelSolver
-- setKeyValuePair
-- shell
+To list all available operations, run `obr run --list-operations` or [`obr operations`](#obr-operations).

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -135,6 +135,10 @@ def run(ctx, **kwargs):
 
     project = OpenFOAMProject().init_project()
 
+    if '--help' == kwargs.get('operations'):
+        project.print_operations()
+        return
+
     if kwargs.get('list_operations'):
         project.print_operations()
         return

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -26,6 +26,23 @@ from .core.parse_yaml import read_yaml
 from .core.queries import input_to_queries, query_impl
 
 
+def check_cli_operations(project: OpenFOAMProject, operations: list[str], list_operations: bool):
+    """ list available operations if none are specified or given the click option or an incorrect op is given"""
+    if list_operations:
+        project.print_operations()
+        return False
+    elif not operations:
+        print('No operation(s) specified.')
+        project.print_operations()
+        print('Syntax: obr run [-o|--operation] <operation>(,<operation>)+')
+        return False
+    elif any((false_op := op) not in project.operations for op in operations):
+        print(f'Specified operation {false_op} is not a valid operation.')
+        project.print_operations()
+        return False
+    return True
+
+
 @click.group()
 @click.option("--debug/--no-debug", default=False)
 @click.pass_context
@@ -62,18 +79,8 @@ def submit(ctx, **kwargs):
     project._entrypoint = {"executable": "", "path": "obr"}
 
     operations = kwargs.get('operations', "").split(',')
-    # list available operations if none are specified or given the click option or an incorrect op is given
-    if not operations:
-        print('No operation(s) specified.')
-        project.print_operations()
-        print('Syntax: obr run [-o|--operation] <operation>(,<operation>)+')
-        return
-    elif any((false_op := op) not in project.operations for op in operations):
-        print(f'Specified operation {false_op} is not a valid operation.')
-        project.print_operations()
-        return
-    elif kwargs.get('list_operations'):
-        project.print_operations()
+    list_operations = kwargs.get('list_operations')
+    if not check_cli_operations(project, operations, list_operations):
         return
 
     queries_str = kwargs.get("query")
@@ -163,18 +170,8 @@ def run(ctx, **kwargs):
     project = OpenFOAMProject().init_project()
 
     operations = kwargs.get('operations', "").split(',')
-    # list available operations if none are specified or given the click option or an incorrect op is given
-    if not operations:
-        print('No operation(s) specified.')
-        project.print_operations()
-        print('Syntax: obr run [-o|--operation] <operation>(,<operation>)+')
-        return
-    elif any((false_op := op) not in project.operations for op in operations):
-        print(f'Specified operation {false_op} is not a valid operation.')
-        project.print_operations()
-        return
-    elif kwargs.get('list_operations'):
-        project.print_operations()
+    list_operations = kwargs.get('list_operations')
+    if not check_cli_operations(project, operations, list_operations):
         return
 
     queries_str = kwargs.get("query")

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -41,8 +41,19 @@ def cli(ctx, debug):
 @click.option(
     "-p", "--pretend", is_flag=True, help="Set flag to only print submission script"
 )
-@click.option("-o", "--operations", default="", required=True, help="Specify the operation(s) to run. Pass multiple operations after -o, separated by commata (NO space), e.g. obr run -o shell,apply. Run with --help to list available operations.")
-@click.option("-l", "--list-operations", is_flag=True, help="Prints all available operations and returns.")
+@click.option(
+    "-o",
+    "--operations",
+    default="",
+    required=True,
+    help="Specify the operation(s) to run. Pass multiple operations after -o, separated by commata (NO space), e.g. obr run -o shell,apply. Run with --help to list available operations.",
+)
+@click.option(
+    "-l",
+    "--list-operations",
+    is_flag=True,
+    help="Prints all available operations and returns.",
+)
 @click.option("--query", default=None, help="")
 @click.option("--bundling_key", default=None, help="")
 @click.option("-p", "--partition", default="cpuonly")
@@ -61,18 +72,18 @@ def submit(ctx, **kwargs):
     project = OpenFOAMProject().init_project()
     project._entrypoint = {"executable": "", "path": "obr"}
 
-    operations = kwargs.get('operations', "").split(',')
+    operations = kwargs.get("operations", "").split(",")
     # list available operations if none are specified or given the click option or an incorrect op is given
     if not operations:
-        print('No operation(s) specified.')
+        print("No operation(s) specified.")
         project.print_operations()
-        print('Syntax: obr run [-o|--operation] <operation>(,<operation>)+')
+        print("Syntax: obr run [-o|--operation] <operation>(,<operation>)+")
         return
     elif any((false_op := op) not in project.operations for op in operations):
-        print(f'Specified operation {false_op} is not a valid operation.')
+        print(f"Specified operation {false_op} is not a valid operation.")
         project.print_operations()
         return
-    elif kwargs.get('list_operations'):
+    elif kwargs.get("list_operations"):
         project.print_operations()
         return
 
@@ -162,18 +173,18 @@ def run(ctx, **kwargs):
 
     project = OpenFOAMProject().init_project()
 
-    operations = kwargs.get('operations', "").split(',')
+    operations = kwargs.get("operations", "").split(",")
     # list available operations if none are specified or given the click option or an incorrect op is given
     if not operations:
-        print('No operation(s) specified.')
+        print("No operation(s) specified.")
         project.print_operations()
-        print('Syntax: obr run [-o|--operation] <operation>(,<operation>)+')
+        print("Syntax: obr run [-o|--operation] <operation>(,<operation>)+")
         return
     elif any((false_op := op) not in project.operations for op in operations):
-        print(f'Specified operation {false_op} is not a valid operation.')
+        print(f"Specified operation {false_op} is not a valid operation.")
         project.print_operations()
         return
-    elif kwargs.get('list_operations'):
+    elif kwargs.get("list_operations"):
         project.print_operations()
         return
 

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -119,8 +119,19 @@ def submit(ctx, **kwargs):
 
 @cli.command()
 @click.option("-f", "--folder", default=".")
-@click.option("-o", "--operations", default="", required=True, help="Specify the operation(s) to run. Pass multiple operations after -o, separated by commata (NO space), e.g. obr run -o shell,apply. Run with --help to list available operations.")
-@click.option("-l", "--list-operations", is_flag=True, help="Prints all available operations and returns.")
+@click.option(
+    "-o",
+    "--operations",
+    default="",
+    required=True,
+    help="Specify the operation(s) to run. Pass multiple operations after -o, separated by commata (NO space), e.g. obr run -o shell,apply. Run with --help to list available operations.",
+)
+@click.option(
+    "-l",
+    "--list-operations",
+    is_flag=True,
+    help="Prints all available operations and returns.",
+)
 @click.option("-j", "--job")
 @click.option("--args", default="")
 @click.option("-t", "--tasks", default=-1)
@@ -135,11 +146,11 @@ def run(ctx, **kwargs):
 
     project = OpenFOAMProject().init_project()
 
-    if '--help' == kwargs.get('operations'):
+    if "--help" == kwargs.get("operations"):
         project.print_operations()
         return
 
-    if kwargs.get('list_operations'):
+    if kwargs.get("list_operations"):
         project.print_operations()
         return
 
@@ -223,6 +234,7 @@ def operations(ctx, **kwargs):
 
     project = OpenFOAMProject.get_project()
     project.print_operations()
+
 
 @cli.command()
 @click.option("-f", "--folder", default=".")

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -119,7 +119,7 @@ def submit(ctx, **kwargs):
 
 @cli.command()
 @click.option("-f", "--folder", default=".")
-@click.option("-o", "--operations", default="")
+@click.option("-o", "--operations", default="", required=True, help="Specify the operation(s) to run. Pass multiple operations after -o, separated by commata (NO space), e.g. obr run -o shell,apply. Run with --help to list available operations.")
 @click.option("-l", "--list-operations", is_flag=True, help="Prints all available operations and returns.")
 @click.option("-j", "--job")
 @click.option("--args", default="")

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -120,6 +120,7 @@ def submit(ctx, **kwargs):
 @cli.command()
 @click.option("-f", "--folder", default=".")
 @click.option("-o", "--operations", default="")
+@click.option("-l", "--list-operations", is_flag=True, help="Prints all available operations and returns.")
 @click.option("-j", "--job")
 @click.option("--args", default="")
 @click.option("-t", "--tasks", default=-1)
@@ -133,6 +134,11 @@ def run(ctx, **kwargs):
         os.chdir(kwargs["folder"])
 
     project = OpenFOAMProject().init_project()
+
+    if kwargs.get('list_operations'):
+        project.print_operations()
+        return
+
     queries_str = kwargs.get("query")
     queries = input_to_queries(queries_str)
     if queries:
@@ -203,6 +209,16 @@ def status(ctx, **kwargs):
     project = OpenFOAMProject.get_project()
     project.print_status(detailed=kwargs["detailed"], pretty=True)
 
+
+@cli.command()
+@click.option("-f", "--folder", default=".")
+@click.pass_context
+def operations(ctx, **kwargs):
+    if kwargs.get("folder"):
+        os.chdir(kwargs["folder"])
+
+    project = OpenFOAMProject.get_project()
+    project.print_operations()
 
 @cli.command()
 @click.option("-f", "--folder", default=".")

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -20,7 +20,7 @@ import CaseOrigins
 class OpenFOAMProject(flow.FlowProject):
     def print_operations(self):
         ops = sorted(self.operations.keys())
-        print('Available operations are:\n\t', '\n\t '.join(ops))
+        print("Available operations are:\n\t", "\n\t ".join(ops))
         return
 
 

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -18,7 +18,10 @@ import CaseOrigins
 
 
 class OpenFOAMProject(flow.FlowProject):
-    pass
+    def print_operations(self):
+        ops = sorted(self.operations.keys())
+        print('Available operations are:\n\t', '\n\t '.join(ops))
+        return
 
 
 generate = OpenFOAMProject.make_group(name="generate")


### PR DESCRIPTION
Resolves #84. 
With this PR, you can run
- `obr operations`
- `obr run --list-operations`
- `obr run [--operation|-o] --help` 

Whereas all print the following to the console:
```
Available operations are:
	apply
	archive
	blockMesh
	checkMesh
	controlDict
	decomposePar
	fetchCase
	fvSolution
	refineMesh
	runParallelSolver
	setKeyValuePair
	shell```

Of course, documentation is included in this PR as well.