### PR TITLE
Feature/coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,11 @@ jobs:
     - name: Test with pytest
       run: |
         coverage run -m pytest
+        coverage report
 
-    - name: Test with pytest
+    - name: Get total coverage
       run: |
-        export TOTAL=$(coverage report| tail -n 1|grep --only-matching "[0-9]*\%"|grep --only-matching "[0-9*]")
+        export TOTAL=$(coverage report|tail -n 1|grep --only-matching "[0-9]*\%"|grep --only-matching "[0-9*]")
         echo $TOTAL
         echo "COVERAGE=$TOTAL" >> $GITHUB_ENV
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,11 +28,10 @@ jobs:
       run: |
         coverage run -m pytest
 
-
-
     - name: Test with pytest
       run: |
-        export TOTAL=$(coverage report | tail -n 1|grep --only-matching  "[0-9]*\%"|grep --only-matching "[0-9*]")
+        export TOTAL=$(coverage report| tail -n 1|grep --only-matching "[0-9]*\%"|grep --only-matching "[0-9*]")
+        echo $TOTAL
         echo "COVERAGE=$TOTAL" >> $GITHUB_ENV
 
     - name: "Make coverage badge"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Get total coverage
       run: |
-        export TOTAL=$(coverage report|tail -n 1|grep --only-matching "[0-9]*\%"|grep --only-matching "[0-9*]")
+        export TOTAL=$(coverage report|tail -n 1|grep --only-matching "[0-9]*\%"|grep --only-matching "[0-9]*")
         echo $TOTAL
         echo "COVERAGE=$TOTAL" >> $GITHUB_ENV
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,3 +26,20 @@ jobs:
         python -m pip install .
     - name: Test with pytest
       run: pytest
+
+
+    - name: Test with pytest
+      run: echo "COVERAGE=100" >> $GITHUB_ENV
+
+    - name: "Make coverage badge"
+      uses: schneegans/dynamic-badges-action@v1.4.0
+      with:
+        # GIST_TOKEN is a GitHub personal access token with scope "gist".
+        auth: ${{ secrets.GIST_TOKEN }}
+        gistID: 70b77e941a906fc3863661697ea8e864   # replace with your real Gist id.
+        filename: covbadge.json
+        label: Coverage
+        message: ${{ env.COVERAGE }}%
+        minColorRange: 50
+        maxColorRange: 90
+        valColorRange: ${{ env.COVERAGE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,16 +20,20 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest tox tox-gh-actions
+        pip install pytest tox tox-gh-actions coverage
     - name: Install package
       run: |
         python -m pip install .
     - name: Test with pytest
-      run: pytest
+      run: |
+        coverage run -m pytest
+
 
 
     - name: Test with pytest
-      run: echo "COVERAGE=100" >> $GITHUB_ENV
+      run: |
+        export TOTAL=$(coverage report | tail -n 1|grep --only-matching  "[0-9]*\%"|grep --only-matching "[0-9*]")
+        echo "COVERAGE=$TOTAL" >> $GITHUB_ENV
 
     - name: "Make coverage badge"
       uses: schneegans/dynamic-badges-action@v1.4.0

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 # OBR - OpenFOAM Benchmark Runner
 ![Tests](https://github.com/hpsim/obr/actions/workflows/tests.yml/badge.svg)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/greole/70b77e941a906fc3863661697ea8e864/raw/covbadge.json)
-
-
 [![Documentation Status](https://readthedocs.org/projects/obr/badge/?version=latest)](https://obr.readthedocs.io/en/latest/?badge=latest)
 
-The OpenFOAM Benchmark Runner (OBR) is an experimental workflow manager for simple provisioning of complex parameter studies and reproducible simulations. A typical OpenFOAM workflow of seting up a case and various parameter manipulations can be defined using the yaml markup language. OBR is build on top of signac.
+The OpenFOAM Benchmark Runner (OBR) is an experimental workflow manager for
+simple provisioning of complex parameter studies and reproducible simulations.
+A typical OpenFOAM workflow of seting up a case and various parameter
+manipulations can be defined using the yaml markup language. OBR is build on
+top of signac.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 ---
 # OBR - OpenFOAM Benchmark Runner
 ![Tests](https://github.com/hpsim/obr/actions/workflows/tests.yml/badge.svg)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/greole/70b77e941a906fc3863661697ea8e864/raw/covbadge.json)
+
+
 [![Documentation Status](https://readthedocs.org/projects/obr/badge/?version=latest)](https://obr.readthedocs.io/en/latest/?badge=latest)
 
 The OpenFOAM Benchmark Runner (OBR) is an experimental workflow manager for simple provisioning of complex parameter studies and reproducible simulations. A typical OpenFOAM workflow of seting up a case and various parameter manipulations can be defined using the yaml markup language. OBR is build on top of signac.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,12 @@ dependencies = [
 doc = [
     "sphinx~=4.2.0",
     "sphinx-autoapi",
-    "myst_parser",
+    "myst_parser"
+]
+test = [
     "pytest",
+    "coverage",
+    "gitpython"
 ]
 
 [tool.black]


### PR DESCRIPTION
This PR enables logging of the test coverage and creating a dynamic badge using this approach https://nedbatchelder.com/blog/202209/making_a_coverage_badge.html 

We could extend this to generate more badges. I think the current coverage of 98% seems to be unrealistically high. Maybe we need to dig a bit more into how coverage or pytest -cov works behind the scenes.

Additonally missing dependencies are specified in pyproject.toml