### PR TITLE
Enh/view to jobid

### DIFF
--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -292,6 +292,7 @@ def status(ctx: click.Context, **kwargs):
         os.chdir(kwargs["folder"])
     project = OpenFOAMProject.get_project()
     project.print_status(detailed=kwargs["detailed"], pretty=True)
+    print(map_view_folder_to_job_id("view"))
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -300,24 +300,22 @@ def status(ctx: click.Context, **kwargs):
     finished, unfinished = [], []
     for job in project:
         jobid = job.id
-        if view:= id_view_map.get(jobid):
-            # print(jobid, view, project.labels(job), project.get_job_status(job)) 
+        if view := id_view_map.get(jobid):
+            # print(jobid, view, project.labels(job), project.get_job_status(job))
             labels = project.labels(job)
             if "finished" in labels:
-               finished.append((view, jobid, labels)) 
+                finished.append((view, jobid, labels))
             else:
-               unfinished.append((view, jobid, labels)) 
+                unfinished.append((view, jobid, labels))
             print(f"case: {view}")
-            print(f"id: {jobid}\nlabels: {','.join(labels)}") 
-            print("-"*80)
+            print(f"id: {jobid}\nlabels: {','.join(labels)}")
+            print("-" * 80)
     print("finished:")
     for view, jobid, labels in finished:
         print(view, jobid)
     print("unfinished:")
     for view, jobid, labels in unfinished:
         print(view, jobid)
-
-
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -298,22 +298,24 @@ def status(ctx: click.Context, **kwargs):
     logging.info("Detailed overview:\n" + "=" * 80)
 
     finished, unfinished = [], []
+    max_view_len = 0
     for job in project:
         jobid = job.id
         if view := id_view_map.get(jobid):
             labels = project.labels(job)
+            max_view_len = max(len(view), max_view_len)
             if "finished" in labels:
                 finished.append((view, jobid, labels))
             else:
                 unfinished.append((view, jobid, labels))
-    logging.info("finished:")
     finished.sort()
     for view, jobid, labels in finished:
-        logging.info(view, jobid)
-    logging.info("unfinished:")
+        pad = " " * (max_view_len - len(view) + 1)
+        logging.info(f"{view}:{pad}| F | {jobid}")
     unfinished.sort()
     for view, jobid, labels in unfinished:
-        logging.info(view, jobid)
+        pad = " " * (max_view_len - len(view) + 1)
+        logging.info(f"{view}:{pad}| U | {jobid}")
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -295,25 +295,23 @@ def status(ctx: click.Context, **kwargs):
     project.print_status(detailed=kwargs["detailed"], pretty=True)
     id_view_map = map_view_folder_to_job_id("view")
 
-    print("Detailed overview:\n===================")
+    print("Detailed overview:\n" + "=" * 80)
 
     finished, unfinished = [], []
     for job in project:
         jobid = job.id
         if view := id_view_map.get(jobid):
-            # print(jobid, view, project.labels(job), project.get_job_status(job))
             labels = project.labels(job)
             if "finished" in labels:
                 finished.append((view, jobid, labels))
             else:
                 unfinished.append((view, jobid, labels))
-            print(f"case: {view}")
-            print(f"id: {jobid}\nlabels: {','.join(labels)}")
-            print("-" * 80)
     print("finished:")
+    finished.sort()
     for view, jobid, labels in finished:
         print(view, jobid)
     print("unfinished:")
+    unfinished.sort()
     for view, jobid, labels in unfinished:
         print(view, jobid)
 

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -24,6 +24,7 @@ from .signac_wrapper.operations import OpenFOAMProject, get_values
 from .create_tree import create_tree
 from .core.parse_yaml import read_yaml
 from .core.queries import input_to_queries, query_impl
+from .core.core import map_view_folder_to_job_id
 from pathlib import Path
 import logging
 from subprocess import check_output
@@ -292,7 +293,31 @@ def status(ctx: click.Context, **kwargs):
         os.chdir(kwargs["folder"])
     project = OpenFOAMProject.get_project()
     project.print_status(detailed=kwargs["detailed"], pretty=True)
-    print(map_view_folder_to_job_id("view"))
+    id_view_map = map_view_folder_to_job_id("view")
+
+    print("Detailed overview:\n===================")
+
+    finished, unfinished = [], []
+    for job in project:
+        jobid = job.id
+        if view:= id_view_map.get(jobid):
+            # print(jobid, view, project.labels(job), project.get_job_status(job)) 
+            labels = project.labels(job)
+            if "finished" in labels:
+               finished.append((view, jobid, labels)) 
+            else:
+               unfinished.append((view, jobid, labels)) 
+            print(f"case: {view}")
+            print(f"id: {jobid}\nlabels: {','.join(labels)}") 
+            print("-"*80)
+    print("finished:")
+    for view, jobid, labels in finished:
+        print(view, jobid)
+    print("unfinished:")
+    for view, jobid, labels in unfinished:
+        print(view, jobid)
+
+
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -32,12 +32,12 @@ from git.repo import Repo
 from git.util import Actor
 from git import InvalidGitRepositoryError
 from datetime import datetime
-from typing import Union
+from typing import Union, Optional, Any
 
 
 def check_cli_operations(
-    project: OpenFOAMProject, operations: list[str], list_operations: bool
-):
+    project: OpenFOAMProject, operations: list[str], list_operations: Optional[Any]
+) -> bool:
     """list available operations if none are specified or given the click option or an incorrect op is given"""
     if operations == ["generate"]:
         return True
@@ -230,7 +230,7 @@ def run(ctx: click.Context, **kwargs):
     jobs = project.get_jobs(filter=filters)
 
     if kwargs.get("args"):
-        os.environ["OBR_CALL_ARGS"] = kwargs.get("args")
+        os.environ["OBR_CALL_ARGS"] = kwargs.get("args", "")
 
     # project._reregister_aggregates()
     # print(project.groups)

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -295,7 +295,7 @@ def status(ctx: click.Context, **kwargs):
     project.print_status(detailed=kwargs["detailed"], pretty=True)
     id_view_map = map_view_folder_to_job_id("view")
 
-    print("Detailed overview:\n" + "=" * 80)
+    logging.info("Detailed overview:\n" + "=" * 80)
 
     finished, unfinished = [], []
     for job in project:
@@ -306,14 +306,14 @@ def status(ctx: click.Context, **kwargs):
                 finished.append((view, jobid, labels))
             else:
                 unfinished.append((view, jobid, labels))
-    print("finished:")
+    logging.info("finished:")
     finished.sort()
     for view, jobid, labels in finished:
-        print(view, jobid)
-    print("unfinished:")
+        logging.info(view, jobid)
+    logging.info("unfinished:")
     unfinished.sort()
     for view, jobid, labels in unfinished:
-        print(view, jobid)
+        logging.info(view, jobid)
 
 
 @cli.command()

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -191,3 +191,13 @@ def writes_files(fns):
             unlink(fn)
     else:
         unlink(fns)
+
+
+def map_view_folder_to_job_id(view_folder: str) -> dict:
+    ret = {}
+    for root, folder, file in os.walk(view_folder):
+        path = Path(root) / folder
+        job_id = None
+        if path.is_symlink():
+            job_id = path.absolute().parts[-1]
+            ret[job_id] = path.resolve()

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -198,8 +198,8 @@ def writes_files(fns):
         unlink(fns)
 
 
-def map_view_folder_to_job_id(view_folder: str) -> dict:
-    """Creates a mapping from from the view schema to the original jobid
+def map_view_folder_to_job_id(view_folder: str) -> dict[str, str]:
+    """Creates a mapping from the view schema to the original jobid
 
     Returns:
     ========
@@ -212,7 +212,7 @@ def map_view_folder_to_job_id(view_folder: str) -> dict:
             path = Path(root) / fold
             job_id = None
             if path.is_symlink():
-                job_id = path.resolve().parts[-1]
+                job_id = path.resolve().name
                 rel_fold = [
                     p
                     for p in path.absolute().parts

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -195,9 +195,14 @@ def writes_files(fns):
 
 def map_view_folder_to_job_id(view_folder: str) -> dict:
     ret = {}
+    base, _, _ = next(os.walk("."))
     for root, folder, file in os.walk(view_folder):
-        path = Path(root) / folder
-        job_id = None
-        if path.is_symlink():
-            job_id = path.absolute().parts[-1]
-            ret[job_id] = path.resolve()
+        for i, fold in enumerate(folder):
+            path = Path(root) / fold
+            job_id = None
+            if path.is_symlink():
+                job_id = path.resolve().parts[-1]
+                rel_fold = [p for p in path.absolute().parts if p not in Path(base).absolute().parts]
+                ret[job_id] = "/".join(rel_fold)
+                folder.pop(i)
+    return ret

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -175,6 +175,7 @@ def modifies_file(fns):
     else:
         unlink(fns)
 
+
 def check_log_for_success(log: Path) -> bool:
     res = check_output(["tail", "-n", "2", log], text=True)
     return ("Finalising" in res) or ("End" in res)
@@ -198,8 +199,14 @@ def writes_files(fns):
 
 
 def map_view_folder_to_job_id(view_folder: str) -> dict:
+    """Creates a mapping from from the view schema to the original jobid
+
+    Returns:
+    ========
+        A dictionary with jobid: view_folder
+    """
     ret = {}
-    base, _, _ = next(os.walk("."))
+    base, _, _ = next(os.walk(view_folder))
     for root, folder, file in os.walk(view_folder):
         for i, fold in enumerate(folder):
             path = Path(root) / fold

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -202,7 +202,11 @@ def map_view_folder_to_job_id(view_folder: str) -> dict:
             job_id = None
             if path.is_symlink():
                 job_id = path.resolve().parts[-1]
-                rel_fold = [p for p in path.absolute().parts if p not in Path(base).absolute().parts]
+                rel_fold = [
+                    p
+                    for p in path.absolute().parts
+                    if p not in Path(base).absolute().parts
+                ]
                 ret[job_id] = "/".join(rel_fold)
                 folder.pop(i)
     return ret

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -175,6 +175,10 @@ def modifies_file(fns):
     else:
         unlink(fns)
 
+def check_log_for_success(log: Path) -> bool:
+    res = check_output(["tail", "-n", "2", log], text=True)
+    return ("Finalising" in res) or ("End" in res)
+
 
 def writes_files(fns):
     """check if this job modifies a file, thus it needs to unlink

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -206,17 +206,19 @@ def map_view_folder_to_job_id(view_folder: str) -> dict[str, str]:
         A dictionary with jobid: view_folder
     """
     ret = {}
-    base, _, _ = next(os.walk(view_folder))
+    base = Path(view_folder)
+    if not base.exists():
+        return {}
     for root, folder, file in os.walk(view_folder):
         for i, fold in enumerate(folder):
             path = Path(root) / fold
             job_id = None
             if path.is_symlink():
                 job_id = path.resolve().name
+                # only keep path parts relative to the start of
+                # of the view folder
                 rel_fold = [
-                    p
-                    for p in path.absolute().parts
-                    if p not in Path(base).absolute().parts
+                    p for p in path.absolute().parts if p not in base.absolute().parts
                 ]
                 ret[job_id] = "/".join(rel_fold)
                 folder.pop(i)

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -45,7 +45,7 @@ def logged_execute(cmd, path, doc):
     from datetime import datetime
 
     check_output(["mkdir", "-p", ".obr_store"], cwd=path)
-    d = doc.get("obr", {})
+    d = doc["history"]
     cmd_str = " ".join(cmd)
     cmd_str = path_to_key(cmd_str).split()  # replace dots in cmd_str with _dot_'s
     if len(cmd_str) > 1:
@@ -87,10 +87,9 @@ def logged_execute(cmd, path, doc):
             fh.write(log)
         log = fn
 
-    res = d.get(cmd_str, [])
-
-    res.append(
+    d.append(
         {
+            "cmd": cmd_str,
             "type": "shell",
             "log": log,
             "state": state,
@@ -98,8 +97,8 @@ def logged_execute(cmd, path, doc):
             "timestamp": timestamp,
         }
     )
-    d[cmd_str] = res
-    doc["obr"] = d
+
+    doc["history"] = d
 
 
 def logged_func(func, doc, **kwargs):

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -214,11 +214,9 @@ def map_view_folder_to_job_id(view_folder: str) -> dict[str, str]:
             job_id = None
             if path.is_symlink():
                 job_id = path.resolve().name
-                # only keep path parts relative to the start of
-                # of the view folder
-                rel_fold = [
-                    p for p in path.absolute().parts if p not in base.absolute().parts
-                ]
-                ret[job_id] = "/".join(rel_fold)
+                # only keep path parts relative to the start of of the view
+                # folder
+                if path.absolute().is_relative_to(base.absolute()):
+                    ret[job_id] = str(path.absolute().relative_to(base.absolute()))
                 folder.pop(i)
     return ret

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -339,6 +339,8 @@ def filter_jobs(project, filter: Iterable[str], output: bool = False) -> list[Jo
     jobs: list[Job]
 
     if filter:
+        if isinstance(filter, str):
+            filter = [filter]
         queries = build_filter_query(filter)
         sel_jobs = query_impl(project, queries, output=output)
         jobs = [j for j in project if j.id in sel_jobs]

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -139,7 +139,9 @@ def execute_query(query: Query, key, value, latest_only=True, track_keys=list) -
     return query
 
 
-def flatten_jobs(jobs: "OpenFOAMProject") -> dict:
+def flatten_jobs(
+    jobs: "Union[OpenFOAMProject, list[Job]]",
+) -> dict:
     """convert a list of jobs to a dictionary"""
     docs: dict = {}
 
@@ -216,7 +218,7 @@ def query_flat_jobs(
 
 
 def query_to_dict(
-    jobs: "OpenFOAMProject",
+    jobs: "Union[OpenFOAMProject, list[Job]]",
     queries: list[Query],
     output=False,
     latest_only=True,
@@ -300,7 +302,7 @@ def query_to_dataframe(
     return ret
 
 
-def build_filter_query(filters: Union[list[str], tuple[str]]) -> list[Query]:
+def build_filter_query(filters: Iterable[str]) -> list[Query]:
     """This function builds a list of filter queries, where filter queries are queries that request a specific value and has to conform a predicate"""
     q: list[Query] = []
 
@@ -309,9 +311,9 @@ def build_filter_query(filters: Union[list[str], tuple[str]]) -> list[Query]:
     # case query syntax:
     # filter string has no predicate value (e.g. '==', '<='..)
     # => filter is expected to be in query syntax, i.e., "{key:..., value:..., predicate:...}"
-    if not any([pred for pred in Predicates if pred.value in filters[0]]):
+    if not any([pred for pred in Predicates if pred.value in list(filters)[0]]):
         if not isinstance(filters, list):
-            filters = [filters]
+            filters = list(filters)
         return [input_to_query(f) for f in filters]
 
     # case filter syntax:

--- a/src/obr/signac_wrapper/labels.py
+++ b/src/obr/signac_wrapper/labels.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from flow import FlowProject
 from subprocess import check_output
+from ..core.core import check_log_for_success
 
 
 @FlowProject.label
@@ -39,8 +40,7 @@ def finished(job):
     if not solver:
         return False
     solver_log = job.doc["obr"][solver][-1]["log"]
-    res = check_output(["tail", "-n", "1", solver_log], cwd=Path(job.path) / "case")
-    return "Finalising" in res.decode("utf-8")
+    return check_log_for_success(Path(job.path) / "case" / solver_log)
 
 
 @FlowProject.label


### PR DESCRIPTION
This PR introduces a function to map from an existing view folder back to job ids. This will be useful for improving the `obr status` functionality. For now, however, I want to keep this PR minimal, since before fully rewriting `obr status` other issues need to be fixed first.