### PR TITLE
add  preflight check

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Within `LidDrivenCavity3D/workspace` should now have appeared a multitude of dir
 
 also runs all defined operations in the appropriate order.
 
+## Enviromental variables
+
+OBR workflows often rely on enviromental variables to adapt a workflow to specific node or cluster properties. In workflow.yaml files for example `${{env.HOST}}` is replaced by
+`$HOST`. Additionally, `OBR_RUN_CMD` defines the exact call to for parallel runs and `OBR_PREFLIGHT` can call a script to verify your enviroment just before the solver execution.
+
+    export OBR_RUN_CMD="mpirun --bind-to core --map-by core -np {np} {solver} -parallel -case {path}/case >  {path}/case/{solver}_{timestamp}.log 2>&1"
+    export OBR_PREFLIGHT="python3 $HOME/data/code/exasim_project/micro_benchmarks/common/preflight.py"
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Within `LidDrivenCavity3D/workspace` should now have appeared a multitude of dir
 
 also runs all defined operations in the appropriate order.
 
-## Enviromental variables
+## Environmental variables
 
-OBR workflows often rely on enviromental variables to adapt a workflow to specific node or cluster properties. In workflow.yaml files for example `${{env.HOST}}` is replaced by
-`$HOST`. Additionally, `OBR_RUN_CMD` defines the exact call to for parallel runs and `OBR_PREFLIGHT` can call a script to verify your enviroment just before the solver execution.
+OBR workflows often rely on environmental variables to adapt a workflow to specific node or cluster properties. In workflow.yaml files for example `${{env.HOST}}` is replaced by
+`$HOST`. Additionally, `OBR_RUN_CMD` defines the exact call to for parallel runs and `OBR_PREFLIGHT` can call a script to verify your environment just before the solver execution.
 
     export OBR_RUN_CMD="mpirun --bind-to core --map-by core -np {np} {solver} -parallel -case {path}/case >  {path}/case/{solver}_{timestamp}.log 2>&1"
     export OBR_PREFLIGHT="python3 $HOME/data/code/exasim_project/micro_benchmarks/common/preflight.py"

--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ also runs all defined operations in the appropriate order.
 ## Environmental variables
 
 OBR workflows often rely on environmental variables to adapt a workflow to specific node or cluster properties. In workflow.yaml files for example `${{env.HOST}}` is replaced by
-`$HOST`. Additionally, `OBR_RUN_CMD` defines the exact call to for parallel runs and `OBR_PREFLIGHT` can call a script to verify your environment just before the solver execution.
+`$HOST`. Additionally, `OBR_RUN_CMD` defines the exact command to execute for parallel runs and `OBR_PREFLIGHT` can call a script to verify your environment just before the solver execution.
 
     export OBR_RUN_CMD="mpirun --bind-to core --map-by core -np {np} {solver} -parallel -case {path}/case >  {path}/case/{solver}_{timestamp}.log 2>&1"
     export OBR_PREFLIGHT="python3 $HOME/data/code/exasim_project/micro_benchmarks/common/preflight.py"
 
+Additionally, `OBR_SKIP_COMPLETE` defines if a already complete run should be repeated.
 
 ## Contributing
 

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -580,6 +580,9 @@ def run_cmd_builder(job: Job, cmd_format: str, args: dict) -> str:
         preflight_cmd = f"{preflight} > {job.path}/case/preflight_{timestamp}.log && "
         cmd_format = preflight_cmd + cmd_format
 
+    # NOTE we add || true such that the command never fails
+    # otherwise if one execution would fail OBR exits and
+    # the following solver runs would be discarded
     return cmd_format.format(**cli_args) + "|| true"
 
 

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -575,6 +575,11 @@ def run_cmd_builder(job: Job, cmd_format: str, args: dict) -> str:
         "timestamp": timestamp,
         "np": get_number_of_procs(job),
     }
+    preflight = os.environ.get("OBR_PREFLIGHT")
+    if preflight:
+        preflight_cmd = f"{preflight} > {job.path}/case/preflight_{timestamp}.log && "
+        cmd_format = preflight_cmd + cmd_format
+
     return cmd_format.format(**cli_args) + "|| true"
 
 


### PR DESCRIPTION
This PR adds a way to call a script right before solver execution, which get the exact same timestamp. Usage would be to print out the environment variables to validate correct enviroment.