### PR TITLE
Obr status bugfix

### DIFF
--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from subprocess import check_output
 from typing import Union
 from datetime import datetime
+from signac.contrib.job import Job
 
 # these are to be replaced with each other
 SIGNAC_PATH_TOKEN = "_dot_"
@@ -141,11 +142,17 @@ def logged_func(func, doc, **kwargs):
     doc["history"].append(res)
 
 
-def get_latest_log(job):
+def get_latest_log(job: Job):
     """find latest"""
     from ..OpenFOAM.case import OpenFOAMCase
 
-    case = OpenFOAMCase(str(job.path) + "/case", job)
+    case_path = Path(job.path + "case")
+    # in case obr status is called directly after initialization
+    # this would also fail if there was no case directory
+    if not case_path.exists():
+        return ""
+
+    case = OpenFOAMCase(case_path, job)
     solver = case.controlDict.get("application")
 
     history = job.doc["history"]


### PR DESCRIPTION
`obr status` throws with `AttributeError: 'File' object has no attribute '_dict'` when a job does not have a case folder.

This PR simply adds an existence check for the case folder path, as well as a missing type hint.
This could also be related, or even fix #124 .