### PR TITLE
fix error when status is run on empty workspace

### DIFF
--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -517,7 +517,7 @@ def archive(ctx: click.Context, **kwargs):
 
     # setup project and jobs
     project = OpenFOAMProject().init_project()
-    filters: list[str] = kwargs.get("filter")
+    filters: list[str] = list(kwargs.get("filter", ()))
     # check if given path points to valid project
     if not is_valid_workspace(filters):
         return

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -408,7 +408,6 @@ def query(ctx: click.Context, **kwargs):
         os.chdir(kwargs["folder"])
 
     project = OpenFOAMProject.get_project()
-<<<<<<< HEAD
     filters: tuple[str] = kwargs.get("filter", ())
     if not is_valid_workspace(filters or []):
         return
@@ -421,16 +420,6 @@ def query(ctx: click.Context, **kwargs):
         return
     queries: list[Query] = build_filter_query(input_queries)
     project.get_jobs(filter=list(filters), query=queries, output=output)
-=======
-    filters = kwargs.get("filter")
-
-    # check if given path points to valid project
-
-    queries_str = kwargs.get("query", "")
-    output = kwargs["verbose"]
-    queries = input_to_queries(queries_str)
-    project.get_jobs(filter=filters, query=queries, output=output)
->>>>>>> 03e208e (refactor, check project validity for all operations)
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -319,13 +319,19 @@ def status(ctx: click.Context, **kwargs):
     if kwargs.get("folder"):
         os.chdir(kwargs["folder"])
     project = OpenFOAMProject.get_project()
-    filters = kwargs.get("filter")
+    filters = kwargs.get("filter", [])
+    jobs = project.get_jobs(filter=filters)
+    if len(jobs) == 0:
+        if filters == []:
+            logging.warning("No jobs found in workspace folder!")
+            return
+        logging.warning(f"Found no jobs that satisfy the given filter {filters}!")
+        return
     project.print_status(detailed=kwargs["detailed"], pretty=True)
     id_view_map = map_view_folder_to_job_id("view")
 
     finished, unfinished = [], []
     max_view_len = 0
-    jobs = project.get_jobs(filter=filters)
     logging.info("Detailed overview:\n" + "=" * 80)
     for job in jobs:
         jobid = job.id

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -58,6 +58,10 @@ def check_cli_operations(
 
 
 def is_valid_workspace(filters: list = []) -> bool:
+    """This function checks if:
+    - the `workspace` folder is not empty, and
+    - applying filters would return an empty list
+    """
     project: OpenFOAMProject = OpenFOAMProject.get_project()
     jobs: list[Job] = project.get_jobs(filter=filters)
     if len(jobs) == 0:

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -266,11 +266,11 @@ def run(ctx: click.Context, **kwargs):
     if not check_cli_operations(project, operations, list_operations):
         return
 
-    filters = kwargs.get("filter")
+    filters: list[str] = kwargs.get("filter")
     # check if given path points to valid project
-    if not is_valid_workspace(filters or []):
+    if not is_valid_workspace(filters):
         return
-    jobs = project.get_jobs(filter=filters or [])
+    jobs = project.get_jobs(filter=filters)
 
     if kwargs.get("args"):
         os.environ["OBR_CALL_ARGS"] = kwargs.get("args", "")
@@ -334,6 +334,7 @@ def init(ctx: click.Context, **kwargs):
     "--filter",
     type=str,
     multiple=True,
+    default=[],
     help=(
         "Pass a <key><predicate><value> value pair per occurrence of --filter."
         " Predicates include ==, !=, <=, <, >=, >. For instance, obr submit --filter"
@@ -345,11 +346,11 @@ def status(ctx: click.Context, **kwargs):
     if kwargs.get("folder"):
         os.chdir(kwargs["folder"])
     project = OpenFOAMProject.get_project()
-    filters = kwargs.get("filter")
-    jobs = project.get_jobs(filter=filters or [])
+    filters: list[str] = kwargs.get("filter")
+    jobs = project.get_jobs(filter=filters)
 
     # check if given path points to valid project
-    if not is_valid_workspace(filters or []):
+    if not is_valid_workspace(filters):
         return
 
     project.print_status(detailed=kwargs["detailed"], pretty=True)
@@ -412,8 +413,8 @@ def query(ctx: click.Context, **kwargs):
         os.chdir(kwargs["folder"])
 
     project = OpenFOAMProject.get_project()
-    filters: tuple[str] = kwargs.get("filter", ())
-    if not is_valid_workspace(filters or []):
+    filters: list[str] = list(kwargs.get("filter", ()))
+    if not is_valid_workspace(filters):
         return
 
     input_queries: tuple[str] = kwargs.get("query", ())
@@ -516,11 +517,11 @@ def archive(ctx: click.Context, **kwargs):
 
     # setup project and jobs
     project = OpenFOAMProject().init_project()
-    filters = kwargs.get("filter")
+    filters: list[str] = kwargs.get("filter")
     # check if given path points to valid project
-    if not is_valid_workspace(filters or []):
+    if not is_valid_workspace(filters):
         return
-    jobs = project.filter_jobs(filters or [], False)
+    jobs = project.filter_jobs(filters, False)
 
     dry_run = kwargs.get("dry_run", False)
     branch_name = None

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -57,6 +57,20 @@ def check_cli_operations(
     return True
 
 
+def is_valid_workspace(filters: list = []) -> bool:
+    project: OpenFOAMProject = OpenFOAMProject.get_project()
+    jobs: list[Job] = project.get_jobs(filter=filters)
+    if len(jobs) == 0:
+        if filters == []:
+            logging.warning("No jobs found in workspace folder!")
+            return False
+        logging.warning(
+            f"Found no jobs that satisfy the given filter(s) {' and '.join(filters)}!"
+        )
+        return False
+    return True
+
+
 def copy_to_archive(
     repo: Union[Repo, None], use_git_repo: bool, src_file: Path, target_file: Path
 ) -> None:
@@ -130,6 +144,11 @@ def submit(ctx: click.Context, **kwargs):
         os.chdir(kwargs["folder"])
 
     project = OpenFOAMProject().init_project()
+
+    # check if given path points to valid project
+    if not is_valid_workspace():
+        return
+
     project._entrypoint = {"executable": "", "path": "obr"}
 
     operations = kwargs.get("operations", "").split(",")
@@ -244,7 +263,10 @@ def run(ctx: click.Context, **kwargs):
         return
 
     filters = kwargs.get("filter")
-    jobs = project.get_jobs(filter=filters)
+    # check if given path points to valid project
+    if not is_valid_workspace(filters or []):
+        return
+    jobs = project.get_jobs(filter=filters or [])
 
     if kwargs.get("args"):
         os.environ["OBR_CALL_ARGS"] = kwargs.get("args", "")
@@ -319,14 +341,13 @@ def status(ctx: click.Context, **kwargs):
     if kwargs.get("folder"):
         os.chdir(kwargs["folder"])
     project = OpenFOAMProject.get_project()
-    filters = kwargs.get("filter", [])
-    jobs = project.get_jobs(filter=filters)
-    if len(jobs) == 0:
-        if filters == []:
-            logging.warning("No jobs found in workspace folder!")
-            return
-        logging.warning(f"Found no jobs that satisfy the given filter {filters}!")
+    filters = kwargs.get("filter")
+    jobs = project.get_jobs(filter=filters or [])
+
+    # check if given path points to valid project
+    if not is_valid_workspace(filters or []):
         return
+
     project.print_status(detailed=kwargs["detailed"], pretty=True)
     id_view_map = map_view_folder_to_job_id("view")
 
@@ -388,6 +409,11 @@ def query(ctx: click.Context, **kwargs):
 
     project = OpenFOAMProject.get_project()
     filters = kwargs.get("filter")
+
+    # check if given path points to valid project
+    if not is_valid_workspace(filters or []):
+        return
+
     queries_str = kwargs.get("query", "")
     output = kwargs["verbose"]
     queries = input_to_queries(queries_str)
@@ -484,11 +510,13 @@ def archive(ctx: click.Context, **kwargs):
 
     # setup project and jobs
     project = OpenFOAMProject().init_project()
-    filters: tuple[str] = kwargs.get("filter", ())
-    jobs = project.filter_jobs(list(filters), False)
+    filters = kwargs.get("filter")
+    # check if given path points to valid project
+    if not is_valid_workspace(filters or []):
+        return
+    jobs = project.filter_jobs(filters or [], False)
 
     dry_run = kwargs.get("dry_run", False)
-    time = str(datetime.now()).replace(" ", "_")
     branch_name = None
     previous_branch = None
     campaign = kwargs["campaign"]

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -30,7 +30,7 @@ class OpenFOAMProject(flow.FlowProject):
         return
 
     def get_jobs(
-        self, filter=list[str], query: Optional[list[Query]] = None, output=False
+        self, filter: list[str], query: Optional[list[Query]] = None, output=False
     ):
         """`get_jobs` accepts a list of filters and an optional list of queries. If `output` is set to True, results will be logged verbosely.
 


### PR DESCRIPTION
Simply checks if the list of jobs is empty while differentiating between "no jobs at all" and "no jobs that satisfy the filter(s)".
closes #128 