### PR TITLE
Issue/query syntax

### DIFF
--- a/docs/source/commandLine/query.md
+++ b/docs/source/commandLine/query.md
@@ -8,14 +8,12 @@ Options:
   -f, --folder TEXT
   --filter TEXT      Pass a <key><predicate><value> value pair per occurrence
                      of --filter. Predicates include ==, !=, <=, <, >=, >. For
-                     instance, obr query --filter "solver==pisoFoam"
+                     instance, obr query --filtersolver==pisoFoam
   -d, --detailed
   -a, --all
-  -q, --query TEXT   Pass a list of dictionary entries in the "{key: '<key>',
-                     value: '<value>', predicate:'<predicate>'}, {...}"
-                     syntax. Predicates include neq, eq, gt, geq, lt, leq. For
-                     instance, obr query -q "{key:'maxIter', value:'300',
-                     predicate:'geq'}"  [required]
+  -q, --query TEXT   Pass a <key><predicate><value> value pair per occurrence
+                     of --query. Predicates include ==, !=, <=, <, >=, >. For
+                     instance, obr query --query solver==pisoFoam  [required]
   -v, --verbose      Set for additional output.
   --help             Show this message and exit.
 ```

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -386,7 +386,7 @@ def query(ctx: click.Context, **kwargs):
     input_queries: tuple[str] = kwargs.get("query", ())
     output: bool = kwargs.get("verbose", False)
     # queries = input_to_queries(queries_str)
-    if input_queries == (""):
+    if input_queries == "":
         logging.warning("--query argument cannot be empty!")
         return
     queries: list[Query] = build_filter_query(input_queries)

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -24,7 +24,7 @@ from signac.contrib.job import Job
 from .signac_wrapper.operations import OpenFOAMProject, get_values, OpenFOAMCase
 from .create_tree import create_tree
 from .core.parse_yaml import read_yaml
-from .core.queries import input_to_queries, query_impl
+from .core.queries import input_to_queries, query_impl, build_filter_query, Query
 from .core.core import map_view_folder_to_job_id
 from pathlib import Path
 import logging
@@ -355,7 +355,7 @@ def status(ctx: click.Context, **kwargs):
     help=(
         "Pass a <key><predicate><value> value pair per occurrence of --filter."
         " Predicates include ==, !=, <=, <, >=, >. For instance, obr query --filter"
-        ' "solver==pisoFoam"'
+        "solver==pisoFoam"
     ),
 )
 @click.option("-d", "--detailed", is_flag=True)
@@ -364,11 +364,11 @@ def status(ctx: click.Context, **kwargs):
     "-q",
     "--query",
     required=True,
+    multiple=True,
     help=(
-        "Pass a list of dictionary entries in the \"{key: '<key>', value: '<value>',"
-        " predicate:'<predicate>'}, {...}\" syntax. Predicates include neq, eq, gt,"
-        " geq, lt, leq. For instance, obr query -q \"{key:'maxIter', value:'300',"
-        " predicate:'geq'}\""
+        "Pass a <key><predicate><value> value pair per occurrence of --query."
+        " Predicates include ==, !=, <=, <, >=, >. For instance, obr query --query"
+        " solver==pisoFoam"
     ),
 )
 @click.option(
@@ -381,11 +381,16 @@ def query(ctx: click.Context, **kwargs):
         os.chdir(kwargs["folder"])
 
     project = OpenFOAMProject.get_project()
-    filters = kwargs.get("filter")
-    queries_str = kwargs.get("query", "")
-    output = kwargs["verbose"]
-    queries = input_to_queries(queries_str)
-    project.get_jobs(filter=filters, query=queries, output=output)
+    filters: tuple[str] = kwargs.get("filter", ())
+    # queries_str = kwargs.get("query", "")
+    input_queries: tuple[str] = kwargs.get("query", ())
+    output: bool = kwargs.get("verbose", False)
+    # queries = input_to_queries(queries_str)
+    if input_queries == (""):
+        logging.warning("--query argument cannot be empty!")
+        return
+    queries: list[Query] = build_filter_query(input_queries)
+    project.get_jobs(filter=list(filters), query=queries, output=output)
 
 
 @cli.command()

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -70,7 +70,7 @@ class Query:
         # case: specific value, existent key. This is effectively a filter.
         try:
             # NOTE this sadly doesnt work when value is an integer, and self.value is a float
-            # so, quickly convert value to a float to avoid casting erros
+            # so, quickly convert value to a float to avoid casting errors
             if isinstance(value, (int, float)):
                 value = float(value)
             # convert value to target type to avoid TypeErrors

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -69,7 +69,8 @@ class Query:
 
         # case: specific value, existent key. This is effectively a filter.
         try:
-            # NOTE this sadly doesnt work for e.g. NoSubdomains, when self.value==0.25 and value is 1
+            # NOTE this sadly doesnt work when value is an integer, and self.value is a float
+            # so, quickly convert value to a float to avoid casting erros
             if isinstance(value, (int, float)):
                 value = float(value)
             # convert value to target type to avoid TypeErrors
@@ -307,19 +308,7 @@ def build_filter_query(filters: Iterable[str]) -> list[Query]:
     """This function builds a list of filter queries, where filter queries are queries that request a specific value and has to conform a predicate"""
     q: list[Query] = []
 
-    # Differentiate between filter and query syntax
-
-    # case query syntax:
-    # filter string has no predicate value (e.g. '==', '<='..)
-    # => filter is expected to be in query syntax, i.e., "{key:..., value:..., predicate:...}"
-    # if not any([pred for pred in Predicates if pred.value in list(filters)[0]]):
-    #     if not isinstance(filters, list):
-    #         filters = list(filters)
-    #     return [input_to_query(f) for f in filters]
-
-    # case filter syntax:
-    # a predicate has been found inside the filter string
-    # => filter is expected to have filter syntax "<key><predicate><value>"
+    # avoid iterating over characters of one filter/query
     if not isinstance(filters, (list, tuple)):
         filters = [filters]
     for filter in filters:

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -30,8 +30,8 @@ class OpenFOAMProject(flow.FlowProject):
         return
 
     def get_jobs(
-        self, filter=list[str], query: Optional[list[Query]] = None, output=False
-    ):
+        self, filter: list[str], query: Optional[list[Query]] = None, output=False
+    ) -> list[Job]:
         """`get_jobs` accepts a list of filters and an optional list of queries. If `output` is set to True, results will be logged verbosely.
 
         - First, the filters will be applied to all jobs inside the `OpenFOAMProject` instance.


### PR DESCRIPTION
Queries now follow the filter-similar syntax:
```
>>> obr query --query "endTime" # implicitly: endTime!=None
 
>>> obr query --query "endTime" --query "numberOfSubDomains==0.25"
[queries.py:334]	WARNING: No applicable predicate found in filter='endTime'. Will assume '!= None'.
[queries.py:329]	  INFO: Found predicate Predicates.eq in filter='numberOfSubDomains==0.25'
[queries.py:249]	  INFO: Query results for endTime != Any::
[queries.py:251]	  INFO: 	Job: c2296b32f084287ad4fd400bda4adc53, result: [{'endTime': 50.0, 'numberOfSubDomains': 0.25}]
[queries.py:251]	  INFO: 	Job: 6394ca209adbe476082540e0070cdeb6, result: [{'endTime': 50.0, 'numberOfSubDomains': 0.25}]
...
```
closes #116 