### PR TITLE
set JOB_ID to avoid duplicate executions

### DIFF
--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -250,7 +250,7 @@ def run(ctx: click.Context, **kwargs):
         os.environ["OBR_CALL_ARGS"] = kwargs.get("args", "")
 
     if kwargs.get("job"):
-        os.environ.get("OBR_JOB") = kwargs.get("job")
+        os.environ["OBR_JOB"] = kwargs.get("job")
 
     # project._reregister_aggregates()
     # print(project.groups)

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -249,6 +249,9 @@ def run(ctx: click.Context, **kwargs):
     if kwargs.get("args"):
         os.environ["OBR_CALL_ARGS"] = kwargs.get("args", "")
 
+    if kwargs.get("job"):
+        os.environ.get("OBR_JOB") = kwargs.get("job")
+
     # project._reregister_aggregates()
     # print(project.groups)
     # val = list(project._groups.values())[0]


### PR DESCRIPTION
Currently, `runSerialSolver` and `runParallelSolver` execute all jobs with final label even though --job=id is set.

TODO:
- [ ] check if it is required for other operations as well.