### PR TITLE
Common notation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.3.0 (2023-09-14)
+------------------
+- Add common notation see https://github.com/hpsim/OBR/pull/146
+
 0.2.0 (2023-09-14)
 ------------------
 - Add --json=file.json option to obr query, which writes the result of the query to a json file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.2.0"
+version = "0.3.0"
 
 dependencies = [
     "click",

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -63,7 +63,7 @@ def extract_from_operation(operation: dict, value) -> dict:
     2. {common: {c1:v1, c2:v2}, values: [{k:v1},{k:v2}] }
 
     -  the path is derived from the schema key value pair
-    a entry {schema: path/{foo}, values: [{foo: 1}]} will be formated
+    a entry {schema: path/{foo}, values: [{foo: 1}]} will be formatted
     to path/1
 
     Returns: a dictionary with keys, path and args

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -214,7 +214,7 @@ def add_variations(
     return operations
 
 
-def setup_job_doc(job, reset=False):
+def setup_job_doc(job: Job, reset: bool =False) -> None:
     """Sets basic information in the job document"""
 
     # dont overwrite old job state on init so that we can update a tree without

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -164,8 +164,9 @@ def add_variations(
     variation: list,
     parent_job: Job,
     id_path_mapping: dict,
-) -> list:
-    """Recursively adds variations to the project
+) -> list[str]:
+    """Recursively adds variations to the project and initialises the jobs. This
+    creates the workspace/uid folder and signac files as sideeffect.
 
     Returns: A list of all operation names
     """


### PR DESCRIPTION
This PR implements the common notation to allow writing  yaml files with key values more compact

Example:
```
     values:
       - set: solvers/p
         preconditioner: none
         solver: GKOCG
         executor: reference
         matrixFormat: Coo
       - set: solvers/U
         preconditioner: BJ
         solver: GKOBiCGStab         
         executor: reference
         matrixFormat: Coo
```
can now be written as
```
     common:
         executor: reference
         matrixFormat: Coo
     values:
       - set: solvers/p
         preconditioner: none
         solver: GKOCG
       - set: solvers/U
         preconditioner: BJ
         solver: GKOBiCGStab         
```
 
Additionally, 
- unit tests are added
- doc strings are expanded
- some minor refactoring