### PR TITLE
make OpenFOAMProject::print_operations also print generate and execute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.3.2 (unreleased)
+------------------
+- Fix missing of groups in `obr run --list-operations` view, see https://github.com/hpsim/OBR/pull/159. 
+
 0.3.0 (unreleased)
 ------------------
 - Add common notation see https://github.com/hpsim/OBR/pull/146

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,14 +2,11 @@
 Changelog
 =========
 
-0.3.2 (unreleased)
-------------------
-- Fix missing of groups in `obr run --list-operations` view, see https://github.com/hpsim/OBR/pull/159. 
-
 0.3.0 (unreleased)
 ------------------
 - Add common notation see https://github.com/hpsim/OBR/pull/146
 - Make numberOfSubdomains argument in yaml consistent see https://github.com/hpsim/OBR/pull/148
+- Fix missing of groups in `obr run --list-operations` view, see https://github.com/hpsim/OBR/pull/159. 
 - Make view folders relative see https://github.com/hpsim/OBR/pull/164
 
 0.2.0 (2023-09-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "obr"
 version = "0.3.1"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
-    {name = "Gregor Olenik", email = "go@hpsim.de"}
+    {name = "Gregor Olenik", email = "go@hpsim.de"},
+    {name = "Lukas Petermann", email = "lukas.petermann13@gmail.com"}
 ]
 license = {text = "BSD-2-Clause"}
 readme="Readme.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.1"
+version = "0.3.2"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"}

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -30,7 +30,7 @@ class OpenFOAMProject(flow.FlowProject):
         super().__init__(*args, **kwargs)
 
     def print_operations(self):
-        ops = sorted(self.operations.keys())
+        ops = sorted(self.groups.keys())
         logging.info("Available operations are:\n\t" + "\n\t".join(ops))
         return
 


### PR DESCRIPTION
fixes #153 
The output will now be:
```
[operations.py:34]	  INFO: Available operations are:
	apply
	archive
	blockMesh
	checkMesh
	controlDict
	decomposePar
	execute
	fetchCase
	fvSchemes
	fvSolution
	generate
	initialConditions
	refineMesh
	runParallelSolver
	runSerialSolver
	setKeyValuePair
	shell
	transportProperties
	turbulenceProperties
	```
Note, that `execute` was also missing from the list of available operations.