### PR TITLE
Fix missing test badge

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,13 +1,9 @@
 name: Integration tests
 run-name: Integration test on ${{github.ref_name}}
 
+
 on:
-  push:
-    branches:
-      - dev
-      - main
-  pull_request:
-    types: synchronize
+  workflow_call
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   unit_tests:
-    uses: ./.github/workflows/unit-test.yml
+    uses: ./.github/workflows/unit_test.yml
   integration_tests:
-    uses: ./.github/workflows/integration-test.yml
+    uses: ./.github/workflows/integration_test.yml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,12 @@ on:
   pull_request:
     types: synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit_tests:
-    uses: ./.github/workflows/unit_test.yml
+    uses: ./.github/workflows/unit_test.yaml
   integration_tests:
-    uses: ./.github/workflows/integration_test.yml
+    uses: ./.github/workflows/integration_test.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,16 @@
+name: Dispatch tests
+run-name: Dispatch tests for ${{github.ref_name}}
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+    types: synchronize
+
+jobs:
+  unit_tests:
+    uses: ./.github/workflows/unit-test.yml
+  integration_tests:
+    uses: ./.github/workflows/integration-test.yml

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.9']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -1,8 +1,7 @@
-name: Tests
+name: Unit tests
 
 on:
-  - push
-  - pull_request
+  workflow_call
 
 jobs:
   unit-test:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -36,6 +36,7 @@ jobs:
         echo "COVERAGE=$TOTAL" >> $GITHUB_ENV
 
     - name: "Make coverage badge"
+      continue-on-error: true
       uses: schneegans/dynamic-badges-action@v1.4.0
       with:
         # GIST_TOKEN is a GitHub personal access token with scope "gist".

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,12 @@ Changelog
 ------------------
 - Add common notation see https://github.com/hpsim/OBR/pull/146
 - Make numberOfSubdomains argument in yaml consistent see https://github.com/hpsim/OBR/pull/148
-- Fix missing of groups in `obr run --list-operations` view, see https://github.com/hpsim/OBR/pull/159. 
+- Fix missing of groups in `obr run --list-operations` view, see https://github.com/hpsim/OBR/pull/159.
 - Make view folders relative see https://github.com/hpsim/OBR/pull/164
 - Use cached version of git repo instead of cloning, see https://github.com/hpsim/OBR/pull/166
 - Bump signac version, see https://github.com/hpsim/OBR/pull/169
 - Validate simulation state after runSerial|ParallelSolver, see https://github.com/hpsim/OBR/pull/168
+- Fix broken test badge, see https://github.com/hpsim/OBR/pull/178
 
 
 0.2.0 (2023-09-14)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **[Documentation](https://obr.readthedocs.io/)**
 ---
 # OBR - OpenFOAM Benchmark Runner
-![Tests](https://github.com/hpsim/obr/actions/workflows/tests.yml/badge.svg)
+![Tests](https://github.com/hpsim/obr/actions/workflows/tests.yaml/badge.svg)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/greole/70b77e941a906fc3863661697ea8e864/raw/covbadge.json)
 [![Documentation Status](https://readthedocs.org/projects/obr/badge/?version=latest)](https://obr.readthedocs.io/en/latest/?badge=latest)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.4"
+version = "0.3.5"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/tests/test_create_tree.py
+++ b/tests/test_create_tree.py
@@ -14,7 +14,7 @@ def emit_test_config():
         "case": {
             "type": "GitRepo",
             "solver": "pisoFoam",
-            "url": "https://github.com/exasim-project/hpc.git"
+            "url": "https://github.com/exasim-project/hpc.git",
             "folder": "Lid_driven_cavity-3d/S",
             "commit": "f9594d16aa6993bb3690ec47b2ca624b37ea40cd",
             "cache_folder": "None/S",

--- a/tests/test_create_tree.py
+++ b/tests/test_create_tree.py
@@ -77,13 +77,11 @@ def test_add_variations():
             return MockJob()
 
     operations = []
-    test_variation = [
-        {
-            "operation": "n/a",
-            "schema": "n/a",
-            "values": [{"foo": 1}, {"foo": 2}, {"foo": 3}],
-        }
-    ]
+    test_variation = [{
+        "operation": "n/a",
+        "schema": "n/a",
+        "values": [{"foo": 1}, {"foo": 2}, {"foo": 3}],
+    }]
     id_path_mapping = {}
     operations = add_variations(
         operations, MockProject(), test_variation, MockJob(), id_path_mapping

--- a/tests/test_create_tree.py
+++ b/tests/test_create_tree.py
@@ -77,11 +77,13 @@ def test_add_variations():
             return MockJob()
 
     operations = []
-    test_variation = [{
-        "operation": "n/a",
-        "schema": "n/a",
-        "values": [{"foo": 1}, {"foo": 2}, {"foo": 3}],
-    }]
+    test_variation = [
+        {
+            "operation": "n/a",
+            "schema": "n/a",
+            "values": [{"foo": 1}, {"foo": 2}, {"foo": 3}],
+        }
+    ]
     id_path_mapping = {}
     operations = add_variations(
         operations, MockProject(), test_variation, MockJob(), id_path_mapping
@@ -166,7 +168,7 @@ def test_cache_folder(tmpdir, emit_test_config):
     # after purgin and recreating the workspace, the cache folder should be used
     Path(f"{tmpdir}/tmp/test").touch()
     shutil.rmtree(workspace_dir)
-    shutil.rmtree(tmpdir /".signac")
+    shutil.rmtree(tmpdir / ".signac")
     project = OpenFOAMProject.init_project(path=tmpdir)
     create_tree(project, emit_test_config, {"folder": tmpdir}, skip_foam_src_check=True)
     project.run(names=["fetchCase"])

--- a/tests/test_create_tree.py
+++ b/tests/test_create_tree.py
@@ -14,7 +14,7 @@ def emit_test_config():
         "case": {
             "type": "GitRepo",
             "solver": "pisoFoam",
-            "url": "https://develop.openfoam.com/committees/hpc.git",
+            "url": "https://github.com/exasim-project/hpc.git"
             "folder": "Lid_driven_cavity-3d/S",
             "commit": "f9594d16aa6993bb3690ec47b2ca624b37ea40cd",
             "cache_folder": "None/S",

--- a/tests/test_md5sum.py
+++ b/tests/test_md5sum.py
@@ -13,7 +13,7 @@ def emit_test_config():
         "case": {
             "type": "GitRepo",
             "solver": "pisoFoam",
-            "url": "https://github.com/exasim-project/hpc.git"
+            "url": "https://github.com/exasim-project/hpc.git",
             "folder": "Lid_driven_cavity-3d/S",
             "commit": "f9594d16aa6993bb3690ec47b2ca624b37ea40cd",
             "cache_folder": "None/S",

--- a/tests/test_md5sum.py
+++ b/tests/test_md5sum.py
@@ -13,7 +13,7 @@ def emit_test_config():
         "case": {
             "type": "GitRepo",
             "solver": "pisoFoam",
-            "url": "https://develop.openfoam.com/committees/hpc.git",
+            "url": "https://github.com/exasim-project/hpc.git"
             "folder": "Lid_driven_cavity-3d/S",
             "commit": "f9594d16aa6993bb3690ec47b2ca624b37ea40cd",
             "cache_folder": "None/S",

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -113,7 +113,7 @@ def get_project(tmpdir):
         "case": {
             "type": "GitRepo",
             "solver": "pisoFoam",
-            "url": "https://develop.openfoam.com/committees/hpc.git",
+            "url": "https://github.com/exasim-project/hpc.git"
             "folder": "Lid_driven_cavity-3d/S",
             "commit": "f9594d16aa6993bb3690ec47b2ca624b37ea40cd",
             "cache_folder": "None/S",

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -113,7 +113,7 @@ def get_project(tmpdir):
         "case": {
             "type": "GitRepo",
             "solver": "pisoFoam",
-            "url": "https://github.com/exasim-project/hpc.git"
+            "url": "https://github.com/exasim-project/hpc.git",
             "folder": "Lid_driven_cavity-3d/S",
             "commit": "f9594d16aa6993bb3690ec47b2ca624b37ea40cd",
             "cache_folder": "None/S",


### PR DESCRIPTION
This PR creates a master workflow for the unit and integration tests, which dispatches to separate unit and integration test runs. This allows to create a badge which indicates success or failure of the combined tests.

Additional changes:
- Prefer github mirror over develop.openfoam.com for cloning test cases since it had some outages recently
- Updating the coverage badge gist seems to fail for no reason, for now I let it fail until we find the reason behind it. 

**Note:**
The badge will appear after merging this PR