### PR TITLE
Improve Readme and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ pip install -e .
 ## Usage
 
 The benchmark runner is split into several layers:
-1. case definition
-2. case generation
-3. case run/submit
-4. case postprocessing
+1. [case definition](https://obr.readthedocs.io/en/latest/overview/case.html) via yaml files
+2. [case generation](https://obr.readthedocs.io/en/latest/overview/generate.html) via `obr init` and `obr run -o generate`
+3. [run or submit solver execution](https://obr.readthedocs.io/en/latest/overview/submit.html) via `obr run -o runParallelSolver` or `obr submit -o runParallelSolver`
+4. [postprocessing cases](https://obr.readthedocs.io/en/latest/overview/postProcessing.html) **Experimental** via, `obr apply` and `obr archive`
 
-### 1. Defining a tree
+### 1. Case definition
 The [micro_benchmarks repository](https://github.com/exasim-project/micro_benchmarks.git) provides a good point to start learning from. After cloning the repository, `cd` into the `LidDrivenCavity3D` directory, where an [example yaml](https://github.com/exasim-project/micro_benchmarks/blob/main/LidDrivenCavity3D/assets/scaling.yaml) file can be found in the case assets folders. Another example of a workflow is shown next
 
 ```
@@ -59,7 +59,7 @@ variation:
 
 The workflow copies an execisting case on disk and creates a [Workspace](#Workspace)
 
-### 2. Creating a tree
+### 2. Case generation
 
 In general, to create a tree of case variations run
 
@@ -70,8 +70,6 @@ Within the context of the `micro_benchmarks` example, simply run
     obr init --folder . --config assets/scaling.yaml
 
 OBR should now print some output, followed by `INFO: successfully initialized`.
-
-### 3. Running a tree
 
 Finally,  operations on a tree can be run with the `obr run` command-line option, for example `fetchCase`, which is responsible for copying the base case into the workspace:
 
@@ -87,13 +85,23 @@ Within `LidDrivenCavity3D/workspace` should now have appeared a multitude of dir
 
 also runs all defined operations in the appropriate order.
 
-### 4. Job submission on HPC cluster
+### 3. Job submission on HPC cluster
 
 On HPC cluster OBR can submit operations via the job queue. For example
 
     obr submit -o blockMesh
 
 will submit the `blockMesh` operation to the cluster manager for every job that is eligible. OBR detects the installed job queuing system, eg. slurm, pbs, etc. A jobs ubmission script will be generated automatically. For fine grained control over the submission script the `--template` argument allows to specify the location of a submission script template. Since OBR uses signac for job submission more details on how to write job submission templates can be found [here](https://docs.signac.io/en/latest/templates.html). To avoid submitting numereous jobs individually, the `--bundling-key` argument can be used to bundle all jobs for which the bundling key has the same value into the same job.
+
+### 4. Postprocessing cases
+
+Since OBR aims at performing parameter studies containing a larger number of individual casses, postprocessing cases manually should be avoided. Its is recommended to use `obr apply` instead.
+
+    obr apply --file script.py --campaign ogl_170
+
+The passed `script.py` file must implement a `call(jobs: list[Job], kwargs={})` function. On execution this gets a list of jobs which allow access to the case paths.
+
+
 
 ## Workspace
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The benchmark runner is split into several layers:
 4. [postprocessing cases](https://obr.readthedocs.io/en/latest/overview/postProcessing.html) **Experimental** via, `obr apply` and `obr archive`
 
 ### 1. Case definition
-The [micro_benchmarks repository](https://github.com/exasim-project/micro_benchmarks.git) provides a good point to start learning from. After cloning the repository, `cd` into the `LidDrivenCavity3D` directory, where an [example yaml](https://github.com/exasim-project/micro_benchmarks/blob/main/LidDrivenCavity3D/assets/scaling.yaml) file can be found in the case assets folders. Another example of a workflow is shown next
+The [micro_benchmarks repository](https://github.com/exasim-project/micro_benchmarks.git) provides a good point to start learning from. After cloning the repository, `cd` into the `LidDrivenCavity3D` directory, where an [example yaml](https://github.com/exasim-project/micro_benchmarks/blob/main/LidDrivenCavity3D/assets/scaling.yaml) file can be found in the case assets folder. Another example of a workflow is shown next
 
 ```
 case:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ variation:
           executor: ${{env.GINKGO_EXECUTOR}}
 ```
 
-The workflow copies an execisting case on disk and creates a [Workspace](#Workspace)
+The workflow copies an existing case on disk and creates a [Workspace](#Workspace).
 
 ### 2. Case generation
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,19 @@ Since OBR aims at performing parameter studies containing a larger number of ind
 
 The passed `script.py` file must implement a `call(jobs: list[Job], kwargs={})` function. On execution this gets a list of jobs which allow access to the case paths.
 
+The mandatory `--campaign` argument is used to separate (families of) experiments. The optional argument `--tag <str>` can be used to further differentiate between experiments within a campaign. Internally, this will create subfolders as such:
 
+    fd52708db5c296d1fa52b056701be4ee
+        ├── campaign1
+        │   ├── tag1
+        │   │   ├── decomposePar_2024-01-05_17:38:44.log
+        │   │   ├── instrumentedPimpleFoam_2024-01-05_17:44:32.log
+        │   │   └── solverExitCode.log
+        │   └── tag2
+        │       ├── decomposePar_2024-01-05_17:38:44.log
+        │       ├── instrumentedPimpleFoam_2024-01-05_17:44:32.log
+        │       └── solverExitCode.log
+        └── campaign2    
 
 ## Workspace
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==5.0.2
+sphinxcontrib.applehelp==1.0.7
+furo==2022.9.29

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "alabaster"
+html_theme = "furo"
 html_static_path = ["_static"]
 
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,4 +1,4 @@
- obr documentation master file, created by
+% obr documentation master file, created by
 % sphinx-quickstart on Mon Jan 30 21:33:58 2023.
 % You can adapt this file completely to your liking, but it should at least
 % contain the root `toctree` directive.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,4 +1,4 @@
-% obr documentation master file, created by
+ obr documentation master file, created by
 % sphinx-quickstart on Mon Jan 30 21:33:58 2023.
 % You can adapt this file completely to your liking, but it should at least
 % contain the root `toctree` directive.
@@ -10,74 +10,15 @@
 :caption: ''
 :maxdepth: 2
 
+yamlFiles/overview
 commandLine/CLI
 troubleshooting/troubleshooting
 ```
 
-
 ```{warning}
 This library is currently under heavy development. Things might change frequently.
 ```
-## Workflow specification
-Workflows are specified via yaml files, for which a  typical yaml file is shown next
 
-    case:
-        type: CaseOnDisk
-        origin: <path_to_original_case>
-    variation:
-     - operation: value
-       values:
-         - key: value
-         - key: value
-       build_pre:
-         - shell: interpreted as shell commands executed before
-         - operation:
-           key: value
-       build_post:
-            - same as build_pre but executed after operation
-       parent:
-            key: value
-       variation:
-            a nested block starting a new variation
-
-Here `operation` can be either a simple key value manipulation of OpenFOAM dictionaries were like `setKeyValuePair` which parses `file` and sets `key` to `value`. Besides 'setKeyValuePair' several convenience wrapper like `controlDict`, 'fvSolution' etc exist.
-
-## Available Operations
-
-## Usage Example
-
-The benchmark runner is split into several layers:
-1. case generation
-2. case run/submit
-3. case postprocessing
-
-The [micro_benchmarks repository](https://github.com/exasim-project/micro_benchmarks/tree/case_windsor_body) provides a good point to start learning from. After cloning the repository, `cd` into the `WindsorBody` subdirectory.
-### 1. Creating a tree
-
-In general, to create a tree of case variation run
-
-    obr init --folder [path] --config path-to-config.yaml
-
-Within the context of the `micro_benchmarks` example, simply run
-
-    obr init --folder . --config assets/scaling.yaml
-
-OBR should now print a low of configuration, followed by `INFO: successfully initialized`.
-
-### 2. Running a tree
-
-Finally, a tree can be run with the `obr run` command-line option:
-
-    obr run -o fetchCase --folder path-to-tree
-
-Or, in this specific example (the default of `--folder` is `.`):
-
-    obr run -o fetchCase
-
-Within `WindsorBody/workspace` should now have appeared a multitude of directories (=cases).
-Not all cases are afflicted by every obr operation. For instance, only the directory named `78e2de3e6205144311d04282001fe21f` should have a further subdirectory named `case`.
-
-Inside `78e2de3e6205144311d04282001fe21f/signac_job_document.json`, the operation is summarized.
 
 # Indices and tables
 

--- a/docs/source/yamlFiles/overview.md
+++ b/docs/source/yamlFiles/overview.md
@@ -1,0 +1,6 @@
+# Yaml files overview
+
+## Structure
+
+
+## Features


### PR DESCRIPTION
Addresses some points from #171 

- [x] Postprocessing steps (this is also missing in the README)
- [x] dark mode (please), switched to furo theme which has a dark mode.
- [x] #174
- [x] `obr archive` and `obr apply` are missing entirely, while `obr operations` exists, but is not supported anymore