### PR TITLE
Auto delink files for Non ESI Foam version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changelog
 - Validate simulation state after runSerial|ParallelSolver, see https://github.com/hpsim/OBR/pull/168
 - Improve obr submit, see https://github.com/hpsim/OBR/pull/170
 - Fix broken test badge, see https://github.com/hpsim/OBR/pull/178
+- Fix decomposePar issues with non ESI versions of OF, see https://github.com/hpsim/OBR/issues/185
+- Automatically create tempory 0 folder before decomposePar, see https://github.com/hpsim/OBR/pull/186
 
 
 0.2.0 (2023-09-14)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,8 @@ Changelog
 - Improve obr submit, see https://github.com/hpsim/OBR/pull/170
 - Fix broken test badge, see https://github.com/hpsim/OBR/pull/178
 - Fix decomposePar issues with non ESI versions of OF, see https://github.com/hpsim/OBR/issues/185
-- Automatically create tempory 0 folder before decomposePar, see https://github.com/hpsim/OBR/pull/186
+- Automatically create temporary 0 folder before decomposePar, see https://github.com/hpsim/OBR/pull/186
 - Fix logfile location for shell commands, see https://github.com/hpsim/OBR/pull/184
-
 
 
 0.2.0 (2023-09-14)

--- a/_typos.toml
+++ b/_typos.toml
@@ -3,3 +3,4 @@ extend-exclude = ["third_party/*"]
 
 [default.extend-words]
 nd = "nd"
+delink = "delink"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.6"
+version = "0.3.7"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.7"
+version = "0.3.8"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -273,6 +273,15 @@ class OpenFOAMCase(BlockMesh):
     def decomposePar(self, args={}):
         """Sets decomposeParDict and calls decomposePar. If no decomposeParDict exists a new one
         gets created"""
+        if not self.time_folder:
+            logging.warning(
+                f"No time folder found! Decomposition might lead to an unusable case."
+            )
+            zero_orig_path = Path(self.path / "0.orig")
+            if zero_orig_path.exists():
+                logging.warning(f"Using existing 0.orig folder")
+                zero_target_path = Path(self.path / "0")
+                check_output(["cp", "-r", zero_orig_path, zero_target_path])
 
         if not self.decomposeParDict:
             decomposeParDictFile = Path(self.system_folder / "decomposeParDict")

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -11,7 +11,13 @@ from datetime import datetime
 from Owls.parser.FoamDict import FileParser
 from Owls.parser.LogFile import LogFile
 
-from ..core.core import logged_execute, logged_func, modifies_file, path_to_key, link_folder_to_copy
+from ..core.core import (
+    logged_execute,
+    logged_func,
+    modifies_file,
+    path_to_key,
+    link_folder_to_copy,
+)
 from .BlockMesh import BlockMesh, calculate_simple_partition
 
 OF_HEADER_REGEX = r"""(/\*--------------------------------\*- C\+\+ -\*----------------------------------\*\\
@@ -272,9 +278,9 @@ class OpenFOAMCase(BlockMesh):
 
     @property
     def esi_version(self) -> bool:
-        """ Check if esi version of OpenFOAM is sourced """
+        """Check if esi version of OpenFOAM is sourced"""
         wm_project_dir = os.environ["WM_PROJECT_DIR"]
-        return (Path(wm_project_dir)/"CONTRIBUTORS.md").exists()
+        return (Path(wm_project_dir) / "CONTRIBUTORS.md").exists()
 
     def decomposePar(self, args={}):
         """Sets decomposeParDict and calls decomposePar. If no decomposeParDict exists a new one
@@ -288,8 +294,9 @@ class OpenFOAMCase(BlockMesh):
             if zero_orig_path.exists():
                 logging.warning(f"Using existing 0.orig folder")
                 zero_target_path = Path(self.path / "0")
-                tmp_zero = TemporaryFolder(zero_orig_path, zero_target_path,
-                    self.esi_version):
+                tmp_zero = TemporaryFolder(
+                    zero_orig_path, zero_target_path, self.esi_version
+                )
 
         constant_folder = None
         if not self.esi_version:

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -16,7 +16,8 @@ from ..core.core import (
     logged_func,
     modifies_file,
     path_to_key,
-    link_folder_to_copy,
+    TemporaryFolder,
+    DelinkFolder,
 )
 from .BlockMesh import BlockMesh, calculate_simple_partition
 

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -270,7 +270,9 @@ class OpenFOAMCase(BlockMesh):
     @property
     def esi_version(self) -> bool:
         """Check if esi version of OpenFOAM is sourced"""
-        wm_project_dir = os.environ["WM_PROJECT_DIR"]
+        wm_project_dir = os.environ.get("WM_PROJECT_DIR")
+        if not wm_project_dir:
+            raise AssertionError("OpenFOAM not sourced. Cannot check OpenFOAM version")
         return (Path(wm_project_dir) / "CONTRIBUTORS.md").exists()
 
     def decomposePar(self, args={}):

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -284,7 +284,7 @@ class OpenFOAMCase(BlockMesh):
             zero_orig_path = self.path / "0.orig"
             if zero_orig_path.exists():
                 logging.warning(f"Using existing 0.orig folder")
-                zero_target_path = Path(self.path / "0")
+                zero_target_path = self.path / "0"
                 tmp_zero = TemporaryFolder(
                     zero_orig_path, zero_target_path, self.esi_version
                 )

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -302,6 +302,8 @@ class OpenFOAMCase(BlockMesh):
         constant_folder = None
         if not self.esi_version:
             constant_folder = DelinkFolder(self.constant_folder)
+            # set a dummy member to avoid issues with autoflake
+            constant_folder.dummy = None
 
         if not self.decomposeParDict:
             decomposeParDictFile = Path(self.system_folder / "decomposeParDict")

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -281,7 +281,7 @@ class OpenFOAMCase(BlockMesh):
             logging.warning(
                 f"No time folder found! Decomposition might lead to an unusable case."
             )
-            zero_orig_path = Path(self.path / "0.orig")
+            zero_orig_path = self.path / "0.orig"
             if zero_orig_path.exists():
                 logging.warning(f"Using existing 0.orig folder")
                 zero_target_path = Path(self.path / "0")

--- a/src/obr/core/caseOrigins.py
+++ b/src/obr/core/caseOrigins.py
@@ -7,6 +7,22 @@ from subprocess import check_output
 import logging
 from git.repo import Repo
 
+class MultiCase:
+    """For now does only create a dummy directory
+    """
+
+    def __init__(self, origin: Union[str, Path], **kwargs):
+        if isinstance(origin, str):
+            origin = expandvars(origin)
+        self.path = Path(origin).expanduser()
+
+    def init(self, path):
+        if not isdir(self.path):
+            logging.warning(
+                f"{self.path.absolute} or some parent directory does not exist!"
+            )
+            return
+        (Path(path) / "case").mkdir(parents=True)
 
 class CaseOnDisk:
     """Copies an OpenFOAM case from disk and copies it into the workspace
@@ -144,6 +160,8 @@ def instantiate_origin_class(
         return OpenFOAMTutorialCase(**args)
     elif class_name == "CaseOnDisk":
         return CaseOnDisk(**args)
+    elif class_name == "MultiCase":
+        return MultiCase(**args)
     else:
         logging.error(
             "'type' must be 'GitRepo', 'OpenFOAMTutorialCase', or 'CaseOnDisk'!"

--- a/src/obr/core/caseOrigins.py
+++ b/src/obr/core/caseOrigins.py
@@ -165,6 +165,6 @@ def instantiate_origin_class(
         return MultiCase(**args)
     else:
         logging.error(
-            "'type' must be 'GitRepo', 'OpenFOAMTutorialCase', or 'CaseOnDisk'!"
+            f"Unknown type {class_name}. 'type' must be 'GitRepo', 'OpenFOAMTutorialCase', or 'CaseOnDisk'!"
         )
         return None

--- a/src/obr/core/caseOrigins.py
+++ b/src/obr/core/caseOrigins.py
@@ -22,7 +22,7 @@ class MultiCase:
                 f"{self.path.absolute} or some parent directory does not exist!"
             )
             return
-        (Path(path) / "case").mkdir(parents=True)
+        os.makedirs(os.path.join(path, "case"))
 
 
 class CaseOnDisk:

--- a/src/obr/core/caseOrigins.py
+++ b/src/obr/core/caseOrigins.py
@@ -7,9 +7,9 @@ from subprocess import check_output
 import logging
 from git.repo import Repo
 
+
 class MultiCase:
-    """For now does only create a dummy directory
-    """
+    """For now does only create a dummy directory"""
 
     def __init__(self, origin: Union[str, Path], **kwargs):
         if isinstance(origin, str):
@@ -23,6 +23,7 @@ class MultiCase:
             )
             return
         (Path(path) / "case").mkdir(parents=True)
+
 
 class CaseOnDisk:
     """Copies an OpenFOAM case from disk and copies it into the workspace

--- a/src/obr/core/caseOrigins.py
+++ b/src/obr/core/caseOrigins.py
@@ -165,6 +165,7 @@ def instantiate_origin_class(
         return MultiCase(**args)
     else:
         logging.error(
-            f"Unknown type {class_name}. 'type' must be 'GitRepo', 'OpenFOAMTutorialCase', or 'CaseOnDisk'!"
+            f"Unknown type {class_name}. 'type' must be 'GitRepo',"
+            " 'OpenFOAMTutorialCase', or 'CaseOnDisk'!"
         )
         return None

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -406,3 +406,19 @@ class DelinkFolder:
     def __del__(self):
         shutil.rmtree(str(self.source))
         check_output(["mv", self.source_bck, self.source])
+
+
+def find_time_folder(path: Path) -> list[Path]:
+    """Given a path this function returns all time folder"""
+
+    def is_time(s: str) -> bool:
+        try:
+            float(s)
+            return True
+        except:
+            return False
+
+    _, fs, _ = next(os.walk(self.path))
+    ret = [self.path / f for f in fs if is_time(f)]
+    ret.sort()
+    return ret

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -373,7 +373,7 @@ def link_folder_to_copy(source: Path) -> Path:
     for fold in folder:
         src_fold_path = src_root / fold
         target_path = targ_root / fn
-        check_output(["cp", "-r", src_path, target_path])
+        check_output(["cp", "-r", src_fold_path, target_path])
     return source_bck
 
 

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -419,6 +419,6 @@ def find_time_folder(path: Path) -> list[Path]:
             return False
 
     _, fs, _ = next(os.walk(self.path))
-    ret = [self.path / f for f in fs if is_time(f)]
+    ret = [path / f for f in fs if is_time(f)]
     ret.sort()
     return ret

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -353,7 +353,7 @@ def link_folder_to_copy(source: Path) -> Path:
     """
     import os
 
-    source_bck = Path(str(source) + ".bck")
+    source_bck = source.absolute() + ".bck"
     check_output(["mv", source, source_bck])
     check_output(["mkdir", source])
     src_root, folder, files = next(os.walk(source_bck))
@@ -375,7 +375,7 @@ def link_folder_to_copy(source: Path) -> Path:
         src_fold_path = src_root / fold
         target_path = targ_root / fn
         check_output(["cp", "-r", src_fold_path, target_path])
-    return source_bck
+    return Path(source_bck)
 
 
 class TemporaryFolder:

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -353,7 +353,7 @@ def link_folder_to_copy(source: Path) -> Path:
     """
     import os
 
-    source_bck = source.absolute() + ".bck"
+    source_bck = str(source.absolute()) + ".bck"
     check_output(["mv", source, source_bck])
     check_output(["mkdir", source])
     src_root, folder, files = next(os.walk(source_bck))

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -373,7 +373,7 @@ def link_folder_to_copy(source: Path) -> Path:
             check_output(["cp", src_file_path, target_file_path])
     for fold in folder:
         src_fold_path = src_root / fold
-        target_path = targ_root / fn
+        target_path = targ_root / fold
         check_output(["cp", "-r", src_fold_path, target_path])
     return Path(source_bck)
 

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -66,14 +66,14 @@ def logged_execute(cmd, path, doc):
         log = ret
         state = "success"
     except subprocess.SubprocessError as e:
+        log = e.output.decode("utf-8")
         logging.error(
             "SubprocessError:"
             + __file__
             + __name__
             + str(e)
-            + " check: 'obr find --state failure' for more info",
+            + log
         )
-        log = e.output.decode("utf-8")
         state = "failure"
     except FileNotFoundError as e:
         logging.error(__file__ + __name__ + str(e))

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -418,7 +418,7 @@ def find_time_folder(path: Path) -> list[Path]:
         except:
             return False
 
-    _, fs, _ = next(os.walk(self.path))
+    _, fs, _ = next(os.walk(path))
     ret = [path / f for f in fs if is_time(f)]
     ret.sort()
     return ret

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -341,6 +341,8 @@ def MultiCase(job: Job, args={}):
     """Dummy operation to generate multiple cases"""
     args = get_args(job, args)
     copy_on_uses(args, job, "system", "controlDict")
+    if not args.get("type"):
+        raise AssertionError("Please specify a type for the MultiCase. Valid types: GitRepo, CaseOnDisk, OpenFOAMTutorialCase")
     instantiate_origin_class(args["type"], args).init(job.path)
 
 

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -542,7 +542,7 @@ def refineMesh(job: Job, args={}):
 @OpenFOAMProject.operation
 def allClean(job: Job, args={}):
     args = get_args(job, args)
-    allCleanPath = Path(job.path) /"case/Allclean"
+    allCleanPath = Path(job.path) / "case/Allclean"
     if allCleanPath.exists():
         check_output(["./Allclean"], cwd=str(job.path) + "/case")
 

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -342,7 +342,10 @@ def MultiCase(job: Job, args={}):
     args = get_args(job, args)
     copy_on_uses(args, job, "system", "controlDict")
     if not args.get("type"):
-        raise AssertionError("Please specify a type for the MultiCase. Valid types: GitRepo, CaseOnDisk, OpenFOAMTutorialCase")
+        raise AssertionError(
+            "Please specify a type for the MultiCase. Valid types: GitRepo, CaseOnDisk,"
+            " OpenFOAMTutorialCase"
+        )
     instantiate_origin_class(args["type"], args).init(job.path)
 
 

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -16,6 +16,7 @@ from .labels import owns_mesh, final, finished
 from ..core.core import execute
 from obr.OpenFOAM.case import OpenFOAMCase
 from obr.core.queries import filter_jobs, query_impl, Query
+from obr.core.caseOrigins import instantiate_origin_class
 
 # TODO operations should get an id/hash so that we can log success
 # TODO add:
@@ -333,6 +334,19 @@ def controlDict(job: Job, args={}):
 @OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
 @OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
 @OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: job.sp().get("operation") == "MultiCase")
+@OpenFOAMProject.post(lambda job: operation_complete(job, "MultiCase"))
+@OpenFOAMProject.operation
+def MultiCase(job: Job, args={}):
+    args = get_args(job, args)
+    print("args", args)
+    instantiate_origin_class(args["type"], args).init(job.path)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
 @OpenFOAMProject.pre(lambda job: basic_eligible(job, "blockMesh"))
 @OpenFOAMProject.post(lambda job: operation_complete(job, "blockMesh"))
 @OpenFOAMProject.operation
@@ -482,6 +496,8 @@ def decomposePar(job: Job, args={}):
 @OpenFOAMProject.operation
 def fetchCase(job: Job, args={}):
     args = get_args(job, args)
+    if args["type"] == "MultiCase":
+        return
 
     uses = args.pop("uses", [])
     case_type = job.sp["type"]
@@ -518,6 +534,16 @@ def refineMesh(job: Job, args={}):
     args = get_args(job, args)
     for _ in range(args.get("value")):
         OpenFOAMCase(str(job.path) + "/case", job).refineMesh(args)
+
+
+@OpenFOAMProject.pre(parent_job_is_ready)
+@OpenFOAMProject.pre(owns_mesh)
+@OpenFOAMProject.operation
+def allClean(job: Job, args={}):
+    args = get_args(job, args)
+    allCleanPath = Path(job.path) /"case/Allclean"
+    if allCleanPath.exists():
+        check_output(["./Allclean"], cwd=str(job.path) + "/case")
 
 
 @OpenFOAMProject.pre(parent_job_is_ready)

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -338,8 +338,9 @@ def controlDict(job: Job, args={}):
 @OpenFOAMProject.post(lambda job: operation_complete(job, "MultiCase"))
 @OpenFOAMProject.operation
 def MultiCase(job: Job, args={}):
+    """Dummy operation to generate multiple cases"""
     args = get_args(job, args)
-    print("args", args)
+    copy_on_uses(args, job, "system", "controlDict")
     instantiate_origin_class(args["type"], args).init(job.path)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,15 @@
 import obr
-from obr.core.core import get_mesh_stats
-from pathlib import Path
+import os
 import pytest
+
+from obr.core.core import (
+    get_mesh_stats,
+    TemporaryFolder,
+    link_folder_to_copy,
+    DelinkFolder,
+)
+from pathlib import Path
+from subprocess import check_output
 
 
 @pytest.fixture
@@ -78,3 +86,69 @@ def test_default_owner(tmpdir, create_of_default_owner):
 def test_obr_has_a_version():
     assert obr.__version__ != ""
     assert obr.__version__ != "0.0.0"
+
+
+def test_TemporaryFolder(tmpdir):
+    def create_tmp_dir(test_dir, test_target):
+        test_file = test_dir / "test_file"
+        with open(test_file, "w") as fh:
+            fh.write("foo")
+        tmp_folder = TemporaryFolder(test_dir, test_target)
+        # test that test_target was created
+        assert test_target.exists()
+        # test that test_target also contains the test file
+        assert (test_target / "test_file").exists()
+
+    tmpdir = Path(tmpdir)
+    test_dir = tmpdir / "test"
+    test_dir.mkdir()
+    test_target_dir = tmpdir / "test_target"
+    create_tmp_dir(test_dir, test_target_dir)
+
+    # outside the scope of create_tmp_dir test_target_dir should
+    # be already deleted
+    assert not test_target_dir.exists()
+
+
+def test_link_folder_to_copy(tmpdir):
+    def create_unlink_dir(source_dir):
+        bck_dir = link_folder_to_copy(source_dir)
+
+        # the backup dir was created
+        assert bck_dir.exists()
+        # the backup contains the test_file
+        assert (bck_dir / "test_file").exists()
+        # the test_file is still a symlink
+        assert (bck_dir / "test_file").is_symlink()
+
+        # the new source path has been created
+        assert source_dir.exists()
+        # the new source contains a  test file
+        assert (source_dir / "test_file").exists()
+        # the new test_file is not a symlink
+        assert not (source_dir / "test_file").is_symlink()
+
+    tmpdir = Path(tmpdir)
+    test_dir = tmpdir / "test"
+    test_dir.mkdir()
+
+    check_output(["ln", "-s", "/bin/bash", test_dir / "test_file"], cwd=tmpdir)
+    create_unlink_dir(test_dir)
+
+
+def test_DelinkFolder(tmpdir):
+    def create_unlink_dir(source_dir):
+        bck_dir = DelinkFolder(source_dir)
+
+        assert source_dir.exists()
+        assert (source_dir / "../test.bck").exists()
+
+    tmpdir = Path(tmpdir)
+    test_dir = tmpdir / "test"
+    test_dir.mkdir()
+
+    check_output(["ln", "-s", "/bin/bash", test_dir / "test_file"], cwd=tmpdir)
+    create_unlink_dir(test_dir)
+
+    # outside the create_unlink_dir the bck folder should not exist anymore
+    assert not (tmpdir / "test.bck").exists()


### PR DESCRIPTION
This PR adds a preliminary multi_case implementation. More importantly, it fixes #185 by checking if the sourced OpenFOAM version is an ESI version. For non ESI versions, it temporarily delinks constant and time folder files. Additionally, this PR adds an automatic check if a timefolder exists before decomposition. If non is present it tries to use a "0.orig" folder if present.