### PR TITLE
Add statepoint filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changelog
 - Improve obr submit, see https://github.com/hpsim/OBR/pull/170
 - Fix broken test badge, see https://github.com/hpsim/OBR/pull/178
 - Fix logfile location for shell commands, see https://github.com/hpsim/OBR/pull/184
-- Add statepoint dependant filter for create_tree, see https://github.com/hpsim/OBR/pull/185
+- Add statepoint dependant filter for create_tree, see https://github.com/hpsim/OBR/pull/187
 
 
 0.2.0 (2023-09-14)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 - Improve obr submit, see https://github.com/hpsim/OBR/pull/170
 - Fix broken test badge, see https://github.com/hpsim/OBR/pull/178
 - Fix logfile location for shell commands, see https://github.com/hpsim/OBR/pull/184
+- Add statepoint dependant filter for create_tree, see https://github.com/hpsim/OBR/pull/185
 
 
 0.2.0 (2023-09-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.8"
+version = "0.3.9"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.7"
+version = "0.3.8"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -118,12 +118,15 @@ def copy_to_archive(
 
 @click.group()
 @click.option("--debug/--no-debug", default=False)
+@click.option("-v", "--version", is_flag=True)
 @click.pass_context
-def cli(ctx: click.Context, debug: bool):
+def cli(ctx: click.Context, **kwargs):
     # ensure that ctx.obj exists and is a dict (in case `cli()` is called
     # by means other than the `if` block below)
+    if kwargs.get("version"):
+        print("obr version")
     ctx.ensure_object(dict)
-    ctx.obj["DEBUG"] = debug
+    ctx.obj["DEBUG"] = kwargs.get("debug")
 
 
 @cli.command()

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -319,18 +319,18 @@ def build_filter_query(filters: Iterable[str]) -> list[Query]:
 
     return q
 
+
 def statepoint_query(statepoint: dict, key: str, value, predicate="=="):
-    """ This function performs a basic recursive query of the statepoint dictionary
-    if the key: value pair is not found in statepoint it recurses into statepoint["parent"] if present 
-    
+    """This function performs a basic recursive query of the statepoint dictionary
+    if the key: value pair is not found in statepoint it recurses into statepoint["parent"] if present
+
     """
     if statepoint.get(key):
-        return statepoint[key] == value 
+        return statepoint[key] == value
     else:
         if statepoint.get("parent"):
             return statepoint_query(statepoint["parent"], key, value, predicate)
     return False
-
 
 
 def filter_jobs(project, filter: Iterable[str], output: bool = False) -> list[Job]:

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -319,6 +319,19 @@ def build_filter_query(filters: Iterable[str]) -> list[Query]:
 
     return q
 
+def statepoint_query(statepoint: dict, key: str, value, predicate="=="):
+    """ This function performs a basic recursive query of the statepoint dictionary
+    if the key: value pair is not found in statepoint it recurses into statepoint["parent"] if present 
+    
+    """
+    if statepoint.get(key):
+        return statepoint[key] == value 
+    else:
+        if statepoint.get("parent"):
+            return statepoint_query(statepoint["parent"], key, value, predicate)
+    return False
+
+
 
 def filter_jobs(project, filter: Iterable[str], output: bool = False) -> list[Job]:
     """`filter` is expected to be a list, string or other iterable of strings in the form of <key><predicate><value>"""

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -214,7 +214,7 @@ def add_variations(
                             "Exact one key-value pair is required for an if record"
                         )
                     key, value = list(filter_record.items())[0]
-                    skip = statepoint_query(statepoint, key, value, predicate)
+                    skip = not statepoint_query(statepoint, key, value, predicate)
                     if skip:
                         logging.debug(
                             f"skipping generating statepoint {statepoint} because of"

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -213,7 +213,7 @@ def add_variations(
                         raise AssertionError(
                             "Exact one key-value pair is required for an if record"
                         )
-                    key, value = list(filter_record.items())[0] 
+                    key, value = list(filter_record.items())[0]
                     skip = statepoint_query(statepoint, key, value, predicate)
                     if skip:
                         logging.debug(

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -201,14 +201,21 @@ def add_variations(
             statepoint["parent"] = base_dict
 
             # check for statepoint filters
-            if isinstance(value, dict) and value.get("if", False) and isinstance(value["if"], dict):
-                statepoint_filter  = value["if"].get("statepoint", {})
+            if (
+                isinstance(value, dict)
+                and value.get("if", False)
+                and isinstance(value["if"], dict)
+            ):
+                statepoint_filter = value["if"].get("statepoint", {})
                 key = statepoint_filter["key"]
                 value = statepoint_filter["value"]
                 if not statepoint_query(
-                        statepoint, key, value,
-                        statepoint_filter.get("predicate", "==")):
-                    logging.debug(f"skipping generating statepoint {statepoint} because of {key}=={value} filter")
+                    statepoint, key, value, statepoint_filter.get("predicate", "==")
+                ):
+                    logging.debug(
+                        f"skipping generating statepoint {statepoint} because of"
+                        f" {key}=={value} filter"
+                    )
                     continue
 
             job = project.open_job(statepoint)

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -210,10 +210,11 @@ def add_variations(
                 for filter_record in value["if"]:
                     predicate = filter_record.pop("predicate", "==")
                     if len(filter_record) != 1:
-                        raise AssertionError("Exact one key-value pair is required for an if record")
-                    skip = statepoint_query(
-                        statepoint, key, value, predicate
-                    )
+                        raise AssertionError(
+                            "Exact one key-value pair is required for an if record"
+                        )
+                    key, value = list(filter_record.items())[0] 
+                    skip = statepoint_query(statepoint, key, value, predicate)
                     if skip:
                         logging.debug(
                             f"skipping generating statepoint {statepoint} because of"


### PR DESCRIPTION
Currently, during the case generation can only be filtered depending on environment variable and simple arithmetic filters. This prohibits creating cases only if the parent cases fulfill certain requirements. This PR introduces a simple additional type of `if ` statement in the config yaml that checks if a matching key value is in the statepoint dictionary. 

**Example:**
The following block checks if the key value pair partition: CPU exists and will only create a case if it evaluates to true. This way we can have for example different GPU and CPU decompositions and not create many unneeded cases.
```
- if: [{partition: CPU, predicate: "=="}, {mesh: 500, predicate: "!="}]
  set: solvers/p
  solver: PCG
  preconditioner: DIC
  executor: CPU
```

We could discuss if we can simplify the if block further by removing the statepoint key i.e. `if: {key: partition, value: CPU }` but perhaps we can use that for different filters that cannot evaluated in the first yaml parse.

**Not implemented**:
At the moment this is implemented quick and dirty. For example the predicates are not used, also this might fails for things other than strings. I think we can improve that in separate PR however.