### PR TITLE
Apply mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Changelog
 - Improve obr submit, see https://github.com/hpsim/OBR/pull/170
 - Fix broken test badge, see https://github.com/hpsim/OBR/pull/178
 - Fix logfile location for shell commands, see https://github.com/hpsim/OBR/pull/184
+- Add 'obr apply' mode, see https://github.com/hpsim/OBR/pull/188
+- Add 'obr --version', see https://github.com/hpsim/OBR/pull/188
 
 
 0.2.0 (2023-09-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.7"
+version = "0.3.8"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -244,14 +244,7 @@ def run(ctx: click.Context, **kwargs):
         os.environ["OBR_JOB"] = kwargs.get("job", "")
 
     if kwargs.get("operations") == "apply":
-        sys.argv.append("--aggregate")
-        sys.argv.append("-t")
-        sys.argv.append("1")
-        project.run(
-            names=operations,
-            progress=True,
-            np=1,
-        )
+        logging.warning("Calling the apply operation via run has been discontinued. Call 'obr apply' directly")
         return
 
     if kwargs.get("operations") == "runParallelSolver":
@@ -448,6 +441,57 @@ def query(ctx: click.Context, **kwargs):
                     print(difference_dict)
                     logging.warn("validation failed")
                     sys.exit(1)
+
+@cli.command()
+@click.option(
+    "-c",
+    "--campaign",
+    type=str,
+    multiple=False,
+    help="",
+)
+@click.option(
+    "--file",
+    type=str,
+    multiple=False,
+    help="",
+)
+@click.option(
+    "--folder",
+    default=".",
+    help="Where to create the worspace and view. Default: '.' ",
+    type=str,
+    help="Path to OpenFOAMProject.",
+)
+@click.option(
+    "--filter",
+    type=str,
+    multiple=True,
+    help=(
+        "Pass a <key><predicate><value> value pair per occurrence of --filter."
+        " Predicates include ==, !=, <=, <, >=, >. For instance, obr run -o"
+        ' runParallelSolver --filter "solver==pisoFoam"'
+    ),
+)
+@click.pass_context
+def apply(ctx: click.Context, **kwargs):
+    project = OpenFOAMProject.init_project(path=kwargs.get("folder"))
+
+    filters: list[str] = kwargs.get("filter", [])
+    # check if given path points to valid project
+    if not is_valid_workspace(filters, path=kwargs.get("folder", None)):
+        return
+    jobs = project.filter_jobs(filters=filters)
+    os.environ["OBR_APPLY_FILE"] = kwargs.get("file", "")
+    os.environ["OBR_APPLY_CAMPAIGN"] = kwargs.get("campaign", "")
+    sys.argv.append("--aggregate")
+    sys.argv.append("-t")
+    sys.argv.append("1")
+    project.run(
+        names=["apply"],
+        progress=True,
+        np=1,
+    )
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -244,7 +244,10 @@ def run(ctx: click.Context, **kwargs):
         os.environ["OBR_JOB"] = kwargs.get("job", "")
 
     if kwargs.get("operations") == "apply":
-        logging.warning("Calling the apply operation via run has been discontinued. Call 'obr apply' directly")
+        logging.warning(
+            "Calling the apply operation via run has been discontinued. Call 'obr"
+            " apply' directly"
+        )
         return
 
     if kwargs.get("operations") == "runParallelSolver":
@@ -441,6 +444,7 @@ def query(ctx: click.Context, **kwargs):
                     print(difference_dict)
                     logging.warn("validation failed")
                     sys.exit(1)
+
 
 @cli.command()
 @click.option(

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -117,6 +117,7 @@ def copy_to_archive(
 
 
 @click.group()
+@click.version_option()
 @click.option("--debug/--no-debug", default=False)
 @click.pass_context
 def cli(ctx: click.Context, debug: bool):

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -463,9 +463,8 @@ def query(ctx: click.Context, **kwargs):
 @click.option(
     "--folder",
     default=".",
-    help="Where to create the worspace and view. Default: '.' ",
+    help="Path to the workspace folder. Default: '.' ",
     type=str,
-    help="Path to OpenFOAMProject.",
 )
 @click.option(
     "--filter",
@@ -479,7 +478,9 @@ def query(ctx: click.Context, **kwargs):
 )
 @click.pass_context
 def apply(ctx: click.Context, **kwargs):
-    project = OpenFOAMProject.init_project(path=kwargs.get("folder"))
+    if kwargs.get("folder"):
+        os.chdir(kwargs["folder"])
+    project = OpenFOAMProject.get_project()
 
     filters: list[str] = kwargs.get("filter", [])
     # check if given path points to valid project


### PR DESCRIPTION
This PR prohibits calling `run -o apply` and introduces a new mode `obr apply`. This makes handling CLI arguments for apply much easier.