### PR TITLE
[Fix] get number of procs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Changelog
 - Add statepoint dependant filter for create_tree, see https://github.com/hpsim/OBR/pull/187
 - Add 'obr apply' mode, see https://github.com/hpsim/OBR/pull/188
 - Add 'obr --version', see https://github.com/hpsim/OBR/pull/188
+- Add 'validateState' operation, see https://github.com/hpsim/OBR/pull/189 
+- Improve 'run*Solver' launch speed, see https://github.com/hpsim/OBR/pull/189 
 
 
 0.2.0 (2023-09-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.9"
+version = "0.3.10"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -320,6 +320,20 @@ def build_filter_query(filters: Iterable[str]) -> list[Query]:
     return q
 
 
+def statepoint_get(statepoint: dict, key: str):
+    """This function performs a basic recursive query of the statepoint dictionary
+    if the key: value pair is not found in statepoint it recurses into statepoint["parent"] if present
+
+    """
+    val = statepoint.get(key)
+    if val:
+        return val
+    else:
+        if statepoint.get("parent"):
+            return statepoint_get(statepoint["parent"], key)
+    return False
+
+
 def statepoint_query(statepoint: dict, key: str, value, predicate="=="):
     """This function performs a basic recursive query of the statepoint dictionary
     if the key: value pair is not found in statepoint it recurses into statepoint["parent"] if present

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -568,7 +568,7 @@ def checkMesh(job: Job, args={}):
 
 
 def get_number_of_procs(job: Job) -> int:
-    """Deduces the number of processor
+    """Deduces the number of processors
     For performance reasons the cache is used to store the number of subdomains
     """
     np = statepoint_get(job.sp(), "numberOfSubdomains")

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from .labels import owns_mesh, final, finished
 from ..core.core import execute_shell
 from obr.OpenFOAM.case import OpenFOAMCase
-from obr.core.queries import filter_jobs, query_impl, Query
+from obr.core.queries import filter_jobs, query_impl, Query, statepoint_get
 from obr.core.caseOrigins import instantiate_origin_class
 
 # TODO operations should get an id/hash so that we can log success

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -655,7 +655,7 @@ def run_cmd_builder(job: Job, cmd_format: str, args: dict) -> str:
     return cmd_format.format(**cli_args) + "|| true" + postflight_cmd
 
 
-def validate_state_impl(job: Job) -> None:
+def validate_state_impl(_: str, job: Job) -> None:
     """Perform a detailed update of the job state"""
     case = OpenFOAMCase(Path(job.path) / "case", job)
     case.detailed_update()

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -666,7 +666,7 @@ def validate_state_impl(job: Job) -> None:
 @OpenFOAMProject.pre(is_job)
 @OpenFOAMProject.operation
 def validateState(job: Job, args={}) -> None:
-    """Dummy opertion which forwards to validate_state_impl. The reason for keeping this function
+    """Dummy operation which forwards to validate_state_impl. The reason for keeping this function
     is that it can be called from the cli to force a detailed update"""
     validate_state_impl(job)
 

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -568,14 +568,25 @@ def checkMesh(job: Job, args={}):
 
 
 def get_number_of_procs(job: Job) -> int:
-    np = int(job.sp().get("numberSubDomains", 0))
+    """Deduces the number of processor
+    For performance reasons the cache is used to store the number of subdomains
+    """
+    np = statepoint_get(job.sp(), "numberOfSubdomains")
     if np:
-        return np
-    return int(
+        return int(np)
+    np = job.doc["cache"].get("numberOfSubdomains", False)
+    if np:
+        return int(np)
+    # Reading from numberOfSubdomains from the decomposeParDict should
+    # be the last resort since it is very expensive
+    np = int(
         OpenFOAMCase(str(job.path) + "/case", job).decomposeParDict.get(
             "numberOfSubdomains"
         )
     )
+    if np:
+        job.doc["cache"]["numberOfSubdomains"] = np
+    return np
 
 
 def get_values(jobs: list, key: str) -> set:
@@ -644,10 +655,20 @@ def run_cmd_builder(job: Job, cmd_format: str, args: dict) -> str:
     return cmd_format.format(**cli_args) + "|| true" + postflight_cmd
 
 
-def validate_state(_: str, job: Job) -> str:
+def validate_state_impl(job: Job) -> None:
     """Perform a detailed update of the job state"""
     case = OpenFOAMCase(Path(job.path) / "case", job)
     case.detailed_update()
+
+
+@OpenFOAMProject.pre(parent_job_is_ready)
+@OpenFOAMProject.pre(final)
+@OpenFOAMProject.pre(is_job)
+@OpenFOAMProject.operation
+def validateState(job: Job, args={}) -> None:
+    """Dummy opertion which forwards to validate_state_impl. The reason for keeping this function
+    is that it can be called from the cli to force a detailed update"""
+    validate_state_impl(job)
 
 
 @simulate
@@ -656,7 +677,7 @@ def validate_state(_: str, job: Job) -> str:
 @OpenFOAMProject.operation(
     cmd=True, directives={"np": lambda job: get_number_of_procs(job)}
 )
-@OpenFOAMProject.operation_hooks.on_exit(validate_state)
+@OpenFOAMProject.operation_hooks.on_exit(validate_state_impl)
 def runParallelSolver(job: Job, args={}) -> str:
     env_run_template = os.environ.get("OBR_RUN_CMD")
     solver_cmd = (
@@ -674,7 +695,7 @@ def runParallelSolver(job: Job, args={}) -> str:
 @OpenFOAMProject.pre(final)
 @OpenFOAMProject.pre(is_job)
 @OpenFOAMProject.operation(cmd=True)
-@OpenFOAMProject.operation_hooks.on_exit(validate_state)
+@OpenFOAMProject.operation_hooks.on_exit(validate_state_impl)
 def runSerialSolver(job: Job, args={}):
     env_run_template = os.environ.get("OBR_SERIAL_RUN_CMD")
     solver_cmd = (


### PR DESCRIPTION
This PR improves the implementation of `get_number_procs` by caching its result.  Furthermore, reading the number of processors from the statepoint has been fixed. This is important since reading number of procs from the decomposeParDict can take quite long and improving the performance should benefit the launch time of the `run*Solver`
operation.

Additionally, this PR adds a new operation: `validateState` which calls the validation function of the OpenFOAM case and might perform expensive operations.