### PR TITLE
Add templated generator blocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changelog
 - Add statepoint dependant filter for create_tree, see https://github.com/hpsim/OBR/pull/187
 - Add 'obr apply' mode, see https://github.com/hpsim/OBR/pull/188
 - Add 'obr --version', see https://github.com/hpsim/OBR/pull/188
+- Add template block generators, see https://github.com/hpsim/OBR/pull/18://github.com/hpsim/OBR/pull/190 
 
 
 0.2.0 (2023-09-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.10"
+version = "0.3.11"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.9"
+version = "0.3.10"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/src/obr/core/parse_yaml.py
+++ b/src/obr/core/parse_yaml.py
@@ -21,13 +21,11 @@ def read_yaml(kwargs: dict) -> str:
         # search for includes
         config_str = add_includes(yaml_location, config_str)
 
-    return eval_yaml_expressions(
-        parse_variables(
-            parse_variables(config_str, dict(os.environ), "env"),
+    return parse_special_variables(
+            parse_special_variables(config_str, dict(os.environ), "env"),
             {"location": str(yaml_location)},
             "yaml",
         )
-    )
 
 
 def add_includes(yaml_location: Path, config_str: str) -> str:
@@ -46,8 +44,8 @@ def add_includes(yaml_location: Path, config_str: str) -> str:
     return config_str
 
 
-def parse_variables(in_str: str, args: dict, domain: str) -> str:
-    """Replaces ${{ domain.value }} expressions with concrete values"""
+def parse_special_variables(in_str: str, args: dict, domain: str) -> str:
+    """Replaces ${{ domain.value }} expressions with environmental variable values"""
     ocurrances = re.findall(r"\${{" + domain + r"\.(\w+)}}", in_str)
     for inst in ocurrances:
         if not args.get(inst, ""):
@@ -58,7 +56,7 @@ def parse_variables(in_str: str, args: dict, domain: str) -> str:
     return in_str
 
 
-def eval_yaml_expressions(in_str: str) -> str:
+def eval_generator_expressions(in_str: str) -> str:
     """Tries evaluate ${{ }} expressions"""
     expr = re.findall(r"\${{([\'\"\= 0.-9()*+A-Za-z_>!]*)}}", in_str)
     for inst in expr:

--- a/src/obr/core/parse_yaml.py
+++ b/src/obr/core/parse_yaml.py
@@ -22,10 +22,10 @@ def read_yaml(kwargs: dict) -> str:
         config_str = add_includes(yaml_location, config_str)
 
     return parse_special_variables(
-            parse_special_variables(config_str, dict(os.environ), "env"),
-            {"location": str(yaml_location)},
-            "yaml",
-        )
+        parse_special_variables(config_str, dict(os.environ), "env"),
+        {"location": str(yaml_location)},
+        "yaml",
+    )
 
 
 def add_includes(yaml_location: Path, config_str: str) -> str:

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -150,7 +150,6 @@ def expand_generator_block(operation):
     """given an operation this function"""
     # check if we have a generator
     if generator := operation.get("generator"):
-        print("operation", operation)
         if not (templates := generator.get("template")):
             raise AssertionError("No template section given.")
         if not (values := generator.get("values")):

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -1,19 +1,3 @@
-#!/usr/bin/python
-"""
-    run ogl benchmarks
-
-    Usage:
-        runBenchmark.py [options]
-
-    Options:
-        -h --help           Show this screen
-        -v --version        Print version and exit
-        --clean             Remove existing cases [default: False].
-        --parameters=<json> pass the parameters for given parameter study
-        --folder=<folder>   Target folder  [default: Test].
-        --init=<ts>         Run the base case for ts timesteps [default: 100].
-"""
-
 import os
 import sys
 import logging
@@ -24,6 +8,7 @@ from subprocess import check_output
 from signac.job import Job
 from obr.signac_wrapper.operations import OpenFOAMProject
 from obr.core.queries import statepoint_query
+from obr.core.parse_yaml import eval_generator_expressions
 from copy import deepcopy
 
 
@@ -179,10 +164,46 @@ def add_variations(
         if not is_on_requested_parent(operation, parent_job):
             continue
 
+        # check if we have a generator
+        if generator := operation.get("generator"):
+            templates = generator.get("template")
+            if not templates:
+                logging.error("No template section given.")
+            values = generator.get("values")
+            if not values:
+                logging.error("No values section given.")
+            key = generator.get("key")
+            if not key:
+                logging.error("No key section given.")
+
+            template_generated = []
+            for val in values:
+                # templates are a list of records
+                # every record needs to be scanned and updated
+                for template in templates:
+                    # template records need to be replaced
+                    # i.e. { numberOfSubdomains : foo, key: value}
+                    # by whatever key and value specify
+                    gen_dict = {}
+                    # next k, v are the key values from the template record
+                    # not to confused with the key value pair from the generator block
+                    for k, v in template.items():
+                        gen_dict[k] = v.replace(key, str(val))
+                        # additionally the original key and current
+                        # val are added so that we can use it in schemas
+                        gen_dict[key] = val
+                    template_generated.append(gen_dict)
+            operation["values"] = template_generated
+
         for value in operation["values"]:
             # support if statetment when values are a subdictionary
             if isinstance(value, dict) and not value.get("if", True):
                 continue
+
+            if isinstance(value, dict):
+                for k, v in value.items():
+                    if isinstance(v, str):
+                        value[k] = eval_generator_expressions(v)
 
             # derive path name from schema or key value
             parse_res = extract_from_operation(operation, value)


### PR DESCRIPTION
This PR adds generator expressions to generate value lists. An example of such could be this:
```
  schema: "decompose/{method}_{partition}_N{nodes}_n{numberOfSubdomains}"
  common:
      method: simple
  generator:
      key: nodes
      values: [1, 2, 4, 6, 8, 10]
      template:
          # GPU decompositions
        - numberOfSubdomains: ${{ 1 * nodes * ${{env.NGPUS}} }}
          partition: GPU
        - numberOfSubdomains: ${{ 2 * nodes * ${{env.NGPUS}} }}
          partition: GPU
          # CPU decomposition
        - numberOfSubdomains: ${{ 1 * nodes * ${{env.NCPUS}} }}
          partition: CPU
```
Here, the value of `nodes` in the template section gets replaced by the entries of `values`. In order to achieve this, the evaluation of the generator expression `${{ }}` has been moved from the `parse_yaml` step to the `create_tree` phase.