### PR TITLE
Enable generate directly after initialization 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changelog
 - Add 'obr --version', see https://github.com/hpsim/OBR/pull/188
 - Add 'validateState' operation, see https://github.com/hpsim/OBR/pull/189 
 - Improve 'run*Solver' launch speed, see https://github.com/hpsim/OBR/pull/189 
+- Add '--generate' flag to 'obr init', see https://github.com/hpsim/OBR/pull/191
 
 
 0.2.0 (2023-09-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.10"
+version = "0.3.11"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.11"
+version = "0.3.12"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -292,9 +292,16 @@ def run(ctx: click.Context, **kwargs):
     default=".",
     help="Where to create the worspace and view. Default: '.' ",
 )
-@click.option("-e", "--execute", default=False)
+@click.option(
+    "-g", "--generate", is_flag=True, help="Call generate directly after init."
+)
 @click.option("-c", "--config", required=True, help="Path to configuration file.")
-@click.option("-t", "--tasks", default=-1, help="Number of tasks to run concurrently.")
+@click.option(
+    "-t",
+    "--tasks",
+    default=-1,
+    help="Number of tasks to run concurrently for generate call.",
+)
 @click.option("-u", "--url", default=None, help="Url to a configuration yaml")
 @click.option("--verbose", default=0, help="set verbosity")
 @click.pass_context
@@ -310,6 +317,14 @@ def init(ctx: click.Context, **kwargs):
     create_tree(project, config, kwargs)
 
     logging.info("successfully initialised")
+
+    if kwargs.get("generate"):
+        logging.info("Generating workspace")
+        project.run(
+            names=["generate"],
+            progress=True,
+            np=kwargs.get("tasks", -1),
+        )
 
 
 @cli.command()


### PR DESCRIPTION
This PR enables to run `obr init -c <path> --generate` to execute generate directly after initialization. 