### PR TITLE
Add basic reset implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changelog
 - Add 'validateState' operation, see https://github.com/hpsim/OBR/pull/189 
 - Improve 'run*Solver' launch speed, see https://github.com/hpsim/OBR/pull/189 
 - Add '--generate' flag to 'obr init', see https://github.com/hpsim/OBR/pull/191
+- Add 'obr reset' mode, see https://github.com/hpsim/OBR/pull/192
 
 
 0.2.0 (2023-09-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.14"
+version = "0.3.15"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -229,6 +229,10 @@ class OpenFOAMCase(BlockMesh):
             return self.latest_log.footer.completed
         return False
 
+    @property
+    def solver(self):
+        return self.controlDict.get("application")
+
     def fetch_logs(self) -> list[Path]:
         solver = self.solver
         root, _, files = next(os.walk(self.path))
@@ -279,6 +283,12 @@ class OpenFOAMCase(BlockMesh):
         if not wm_project_dir:
             raise AssertionError("OpenFOAM not sourced. Cannot check OpenFOAM version")
         return (Path(wm_project_dir) / "CONTRIBUTORS.md").exists()
+
+    def reset_case(self):
+        """Removes all artifacts after case generation"""
+        self.remove_solver_logs()
+
+        self.job.doc["state"]["global"] = "ready"
 
     def decomposePar(self, args={}):
         """Sets decomposeParDict and calls decomposePar. If no decomposeParDict exists a new one

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -236,7 +236,9 @@ class OpenFOAMCase(BlockMesh):
     def fetch_logs(self) -> list[Path]:
         solver = self.solver
         root, _, files = next(os.walk(self.path))
-        log_files = [Path(root) / f for f in files if f.endswith(".log") and f.startswith(solver)]
+        log_files = [
+            Path(root) / f for f in files if f.endswith(".log") and f.startswith(solver)
+        ]
         log_files.sort()
         return log_files
 
@@ -439,7 +441,6 @@ class OpenFOAMCase(BlockMesh):
             # if parsing of log file fails, check failure handler
             self.job.doc["state"]["global"] = "failure"
             return False
-
 
     def detailed_update(self):
         """Perform a detailed update on the job doc state"""

--- a/src/obr/OpenFOAM/case.py
+++ b/src/obr/OpenFOAM/case.py
@@ -229,14 +229,19 @@ class OpenFOAMCase(BlockMesh):
             return self.latest_log.footer.completed
         return False
 
-    def fetch_latest_log(self) -> None:
-        solver = self.controlDict.get("application")
-
+    def fetch_logs(self) -> list[Path]:
+        solver = self.solver
         root, _, files = next(os.walk(self.path))
-        log_files = [f for f in files if f.endswith(".log") and f.startswith(solver)]
+        log_files = [Path(root) / f for f in files if f.endswith(".log") and f.startswith(solver)]
         log_files.sort()
+        return log_files
+
+    def fetch_latest_log(self) -> None:
+        log_files = self.fetch_logs()
         if log_files:
-            self.latest_log_path_ = Path(root) / log_files[-1]
+            self.latest_log_path_ = log_files[-1]
+        else:
+            self.latest_log_path_ = None
 
     @property
     def config_file_tree(self) -> list[str]:
@@ -424,9 +429,15 @@ class OpenFOAMCase(BlockMesh):
             self.job.doc["state"]["global"] = "failure"
             return False
 
+
     def detailed_update(self):
         """Perform a detailed update on the job doc state"""
         self.process_latest_time_stats()
+
+    def remove_solver_logs(self):
+        """Search for solver logs and deletes them"""
+        for log in self.fetch_logs():
+            log = self._exec_operation(["rm", str(log)])
 
     def perform_post_md5sum_calculations(self):
         """

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -493,6 +493,7 @@ def apply(ctx: click.Context, **kwargs):
         np=1,
     )
 
+
 @cli.command()
 @click.option(
     "--filter",
@@ -505,15 +506,21 @@ def apply(ctx: click.Context, **kwargs):
     ),
 )
 @click.option("-w", "--workspace", is_flag=True, help="remove all obr project files")
-@click.option("-c", "--case", is_flag=True, help="reset the state of a case by deleting solver logs")
+@click.option(
+    "-c",
+    "--case",
+    is_flag=True,
+    help="reset the state of a case by deleting solver logs",
+)
 @click.option(
     "-v", "--view", default="", help="remove case completely specified by a view folder"
 )
 @click.pass_context
 def reset(ctx: click.Context, **kwargs):
     """deletes workspace or cases"""
+
     def safe_delete(fn):
-        """This functions deletes the given path. If the path does not exists it does nothing """
+        """This functions deletes the given path. If the path does not exists it does nothing"""
         path = Path(fn)
         if path.exists():
             if path.is_dir():
@@ -527,7 +534,7 @@ def reset(ctx: click.Context, **kwargs):
         logging.warn(
             f"Removing current obr workspace. This will remove all simulation results"
         )
-        if click.confirm('Do you want to continue?', default=True):
+        if click.confirm("Do you want to continue?", default=True):
             safe_delete("workspace")
             safe_delete("view")
             safe_delete("signac.rc")
@@ -537,21 +544,23 @@ def reset(ctx: click.Context, **kwargs):
     if kwargs.get("case"):
         jobids = [j.id for j in jobs]
         logging.warn(
-            f"Reseting obr cases. This will remove all generated simulation results of the following {len(jobids)} jobs {jobids}."
+            "Resetting obr cases. This will remove all generated simulation results of"
+            f" the following {len(jobids)} jobs {jobids}."
         )
         logging.warn(
-            f"obr reset --case, is not fully implemented and will only remove log solver logs."
+            f"obr reset --case, is not fully implemented and will only remove log"
+            f" solver logs."
         )
-        if click.confirm('Do you want to continue?', default=True):
+        if click.confirm("Do you want to continue?", default=True):
             project.run(
-                jobs = jobs,
+                jobs=jobs,
                 names=["resetCase"],
                 progress=True,
                 np=-1,
             )
 
     if kwargs.get("view"):
-        logging.error("Reseting by view path is not yet supported")
+        logging.error("Resetting by view path is not yet supported")
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -517,7 +517,7 @@ def apply(ctx: click.Context, **kwargs):
 @click.option("-w", "--workspace", is_flag=True, help="remove all obr project files")
 @click.option("-c", "--case", is_flag=True, help="reset the state of a case by deleting solver logs")
 @click.option(
-    "-v", "--view", default="remove case completely specified by a view folder"
+    "-v", "--view", default="", help="remove case completely specified by a view folder"
 )
 @click.pass_context
 def reset(ctx: click.Context, **kwargs):
@@ -545,8 +545,9 @@ def reset(ctx: click.Context, **kwargs):
             return
 
     if kwargs.get("case"):
+        jobids = [j.id for j in jobs]
         logging.warn(
-            f"Reseting obr cases. This will remove all generated simulation results."
+            f"Reseting obr cases. This will remove all generated simulation results of the following {len(jobids)} jobs {jobids}."
         )
         logging.warn(
             f"obr reset --case, is not fully implemented and will only remove log solver logs."

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -520,7 +520,7 @@ def reset(ctx: click.Context, **kwargs):
     """deletes workspace or cases"""
 
     def safe_delete(fn):
-        """This functions deletes the given path. If the path does not exists it does nothing"""
+        """This functions deletes the given path. If the path does not exist, it does nothing"""
         path = Path(fn)
         if path.exists():
             if path.is_dir():

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -503,6 +503,65 @@ def apply(ctx: click.Context, **kwargs):
         np=1,
     )
 
+@cli.command()
+@click.option(
+    "--filter",
+    type=str,
+    multiple=True,
+    help=(
+        "Pass a <key><predicate><value> value pair per occurrence of --filter."
+        " Predicates include ==, !=, <=, <, >=, >. For instance, obr run -o"
+        ' runParallelSolver --filter "solver==pisoFoam"'
+    ),
+)
+@click.option("-w", "--workspace", is_flag=True, help="remove all obr project files")
+@click.option("-c", "--case", is_flag=True, help="reset the state of a case by deleting solver logs")
+@click.option(
+    "-v", "--view", default="remove case completely specified by a view folder"
+)
+@click.pass_context
+def reset(ctx: click.Context, **kwargs):
+    """deletes workspace or cases"""
+    def safe_delete(fn):
+        """This functions deletes the given path. If the path does not exists it does nothing """
+        path = Path(fn)
+        if path.exists():
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+
+    project, jobs = cli_cmd_setup(kwargs)
+
+    if kwargs.get("workspace"):
+        logging.warn(
+            f"Removing current obr workspace. This will remove all simulation results"
+        )
+        if click.confirm('Do you want to continue?', default=True):
+            safe_delete("workspace")
+            safe_delete("view")
+            safe_delete("signac.rc")
+            safe_delete(".signac")
+            return
+
+    if kwargs.get("case"):
+        logging.warn(
+            f"Reseting obr cases. This will remove all generated simulation results."
+        )
+        logging.warn(
+            f"obr reset --case, is not fully implemented and will only remove log solver logs."
+        )
+        if click.confirm('Do you want to continue?', default=True):
+            project.run(
+                jobs = jobs,
+                names=["resetCase"],
+                progress=True,
+                np=-1,
+            )
+
+    if kwargs.get("view"):
+        logging.error("Reseting by view path is not yet supported")
+
 
 @cli.command()
 @click.option(

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -665,6 +665,16 @@ def validate_state_impl(_: str, job: Job) -> None:
 @OpenFOAMProject.pre(final)
 @OpenFOAMProject.pre(is_job)
 @OpenFOAMProject.operation
+def resetCase(job: Job, args={}) -> None:
+    """Dummy operation that calls resetCase"""
+    case = OpenFOAMCase(Path(job.path) / "case", job)
+    case.resetCase()
+
+
+@OpenFOAMProject.pre(parent_job_is_ready)
+@OpenFOAMProject.pre(final)
+@OpenFOAMProject.pre(is_job)
+@OpenFOAMProject.operation
 def validateState(job: Job, args={}) -> None:
     """Dummy operation which forwards to validate_state_impl. The reason for keeping this function
     is that it can be called from the cli to force a detailed update"""

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -668,7 +668,7 @@ def validate_state_impl(_: str, job: Job) -> None:
 def resetCase(job: Job, args={}) -> None:
     """Dummy operation that calls resetCase"""
     case = OpenFOAMCase(Path(job.path) / "case", job)
-    case.resetCase()
+    case.reset_case()
 
 
 @OpenFOAMProject.pre(parent_job_is_ready)


### PR DESCRIPTION
This PR add an `obr reset`  mode. It can be used to remove an entire workspace or to reset cases. Resetting cases is
currently, not fully implemented. It instead just cleans all log files. I think, however, it is already something useful to have for further experimentation.