### PR TITLE
Improve obr submit output.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Changelog
 - Use cached version of git repo instead of cloning, see https://github.com/hpsim/OBR/pull/166
 - Bump signac version, see https://github.com/hpsim/OBR/pull/169
 - Validate simulation state after runSerial|ParallelSolver, see https://github.com/hpsim/OBR/pull/168
-- Improve obr submit, see https://github.com/hpsim/OBR/pull/170
+- Improve obr submit, see https://github.com/hpsim/OBR/pull/170 and https://github.com/hpsim/OBR/pull/193
 - Fix broken test badge, see https://github.com/hpsim/OBR/pull/178
 - Fix decomposePar issues with non ESI versions of OF, see https://github.com/hpsim/OBR/issues/185
 - Automatically create temporary 0 folder before decomposePar, see https://github.com/hpsim/OBR/pull/186

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.12"
+version = "0.3.13"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -29,7 +29,6 @@ from git.util import Actor
 from git import InvalidGitRepositoryError
 from datetime import datetime
 from typing import Union, Optional, Any
-from copy import deepcopy
 
 from .signac_wrapper.operations import OpenFOAMProject
 from .signac_wrapper.submit import submit_impl

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -169,6 +169,7 @@ def cli(ctx: click.Context, **kwargs):
 )
 @click.option("--bundling_key", default=None, help="")
 @click.option("-p", "--partition", default="cpuonly")
+@click.option("-t", "--time", default="60")
 @click.option("--account", default="")
 @click.option("--pretend", is_flag=True)
 @click.option(
@@ -191,6 +192,7 @@ def submit(ctx: click.Context, **kwargs):
         template=Path(kwargs.get("template")),
         account=kwargs.get("account"),
         partition=kwargs.get("partition"),
+        time=kwargs.get("time"),
         pretend=kwargs["pretend"],
         bundling_key=kwargs["bundling_key"],
         scheduler_args=kwargs.get("scheduler_args"),

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -418,7 +418,8 @@ def query(ctx: click.Context, **kwargs):
     quiet: bool = kwargs.get("quiet", False)
     json_file: str = kwargs.get("export_to", "")
     validation_file: str = kwargs.get("validate_against", "")
-    profile_call(query_impl, project, input_queries, quiet, json_file, validation_file)
+    filters: list[str] = kwargs.get("filter", [])
+    profile_call(query_impl, project, input_queries, filters, quiet, json_file, validation_file)
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -419,7 +419,9 @@ def query(ctx: click.Context, **kwargs):
     json_file: str = kwargs.get("export_to", "")
     validation_file: str = kwargs.get("validate_against", "")
     filters: list[str] = kwargs.get("filter", [])
-    profile_call(query_impl, project, input_queries, filters, quiet, json_file, validation_file)
+    profile_call(
+        query_impl, project, input_queries, filters, quiet, json_file, validation_file
+    )
 
 
 @cli.command()

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -1,6 +1,10 @@
 import json
+import logging
+
+from copy import deepcopy
 
 from .signac_wrapper.operations import OpenFOAMProject
+from .core.queries import build_filter_query
 
 
 def query_impl(

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -10,6 +10,7 @@ from .core.queries import build_filter_query
 def query_impl(
     project: OpenFOAMProject,
     input_queries: tuple[str],
+    filters: list[str],
     quiet: bool,
     json_file: str,
     validation_file: str,

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -1,0 +1,48 @@
+import json
+
+from .signac_wrapper.operations import OpenFOAMProject
+
+
+def query_impl(
+    project: OpenFOAMProject,
+    input_queries: tuple[str],
+    quiet: bool,
+    json_file: str,
+    validation_file: str,
+):
+    if input_queries == "":
+        logging.warning("--query argument cannot be empty!")
+        return
+    queries: list[Query] = build_filter_query(input_queries)
+    jobs = project.filter_jobs(filters=list(filters))
+    query_results = project.query(jobs=jobs, query=queries)
+    if not quiet:
+        for job_id, query_res in deepcopy(query_results).items():
+            out_str = f"{job_id}:"
+            for k, v in query_res.items():
+                out_str += f" {k}: {v}"
+            logging.info(out_str)
+
+    if json_file:
+        with open(json_file, "w") as outfile:
+            # json_data refers to the above JSON
+            json.dump(query_results, outfile)
+    if validation_file:
+        with open(validation_file, "r") as infile:
+            # json_data refers to the above JSON
+            validation_dict = json.load(infile)
+            if validation_dict.get("$schema"):
+                logging.info("using json schema for validation")
+                from jsonschema import validate
+
+                validate(query_results, validation_dict)
+            else:
+                from deepdiff import DeepDiff
+
+                logging.info("using deepdiff for validation")
+                difference_dict = DeepDiff(validation_dict, query_results)
+
+                if difference_dict:
+                    print(difference_dict)
+                    logging.warn("validation failed")
+                    sys.exit(1)

--- a/src/obr/core/core.py
+++ b/src/obr/core/core.py
@@ -422,3 +422,19 @@ def find_time_folder(path: Path) -> list[Path]:
     ret = [path / f for f in fs if is_time(f)]
     ret.sort()
     return ret
+
+
+def profile_call(f, *args, **kwargs):
+    if os.environ.get("OBR_PROFILE"):
+        logging.info("Generating profile")
+        import cProfile
+        import pstats
+
+        with cProfile.Profile() as pr:
+            f(*args, **kwargs)
+        stats = pstats.Stats(pr)
+        stats.sort_stats(pstats.SortKey.TIME)
+        stats.print_stats()
+        stats.dump_stats(filename="obr_profile.prof")
+    else:
+        f(*args, **kwargs)

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -203,6 +203,7 @@ def add_variations(
             if isinstance(value, dict) and not value.get("if", True):
                 continue
 
+
             if isinstance(value, dict):
                 for k, v in value.items():
                     if isinstance(v, str):
@@ -210,6 +211,11 @@ def add_variations(
 
             # derive path name from schema or key value
             parse_res = extract_from_operation(operation, value)
+
+            # filter any if statements from operation dict
+            parse_res["keys"] = [ k for k in parse_res["keys"] if k != "if" ]
+            parse_res["args"] = { k:v for k,v in parse_res["args"].items() if k != "if" }
+
             clean_path(parse_res["path"])
             base_dict = deepcopy(to_dict(parent_job.sp))
 

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -203,7 +203,6 @@ def add_variations(
             if isinstance(value, dict) and not value.get("if", True):
                 continue
 
-
             if isinstance(value, dict):
                 for k, v in value.items():
                     if isinstance(v, str):
@@ -213,8 +212,10 @@ def add_variations(
             parse_res = extract_from_operation(operation, value)
 
             # filter any if statements from operation dict
-            parse_res["keys"] = [ k for k in parse_res["keys"] if k != "if" ]
-            parse_res["args"] = { k:v for k,v in parse_res["args"].items() if k != "if" }
+            parse_res["keys"] = [k for k in parse_res["keys"] if k != "if"]
+            parse_res["args"] = {
+                k: v for k, v in parse_res["args"].items() if k != "if"
+            }
 
             clean_path(parse_res["path"])
             base_dict = deepcopy(to_dict(parent_job.sp))

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -181,7 +181,7 @@ def _link_path(base: Path, dst: Path, parent_id: str, copy_instead_link: bool):
                             dst=f"{trgt_proc_fold}/{proc_cont}",
                             symlinks=False,
                         )
-            # pop all processor folder to aviod recursing
+            # pop all processor folder to avoid recursing
             pop_idx = [i for i, f in enumerate(folder) if f.startswith("processor")]
             for i in sorted(pop_idx, reverse=True):
                 del folder[i]

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -222,7 +222,7 @@ def initialize_if_required(job: Job) -> bool:
         if job.doc["state"].get("is_initialized"):
             return True
         logging.info(f"Start initialization of case {job.id}")
-        base_path = Path(job.path) / ".." / parent_id / "case"
+        base_path = Path(job.path).parent / parent_id / "case"
         dst_path = Path(job.path) / "case"
         # logging.info(f"linking {base_path} to {dst_path}")
         # shell scripts might change files as side effect hence we copy all files

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -188,7 +188,7 @@ def _link_path(base: Path, dst: Path, parent_id: str, copy_instead_link: bool):
 
         for fold in folder:
             src = Path(root) / fold
-            dst_ = Path(dst) / relative_path / fold
+            dst_ = dst / relative_path / fold
             if not dst_.exists():
                 check_output(
                     [

--- a/src/obr/signac_wrapper/operations.py.bck
+++ b/src/obr/signac_wrapper/operations.py.bck
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+import flow
+import os
+import sys
+import obr.core.caseOrigins as caseOrigins
+import traceback
+import logging
+import json
+
+from pathlib import Path
+from subprocess import check_output
+from signac.job import Job
+from typing import Union, Literal
+from datetime import datetime
+
+from .labels import owns_mesh, final, finished
+from ..core.core import execute_shell
+from obr.OpenFOAM.case import OpenFOAMCase
+from obr.core.queries import filter_jobs, query_impl, Query, statepoint_get
+from obr.core.caseOrigins import instantiate_origin_class
+
+# TODO operations should get an id/hash so that we can log success
+# TODO add:
+# - reconstructPar
+# - unlockTmpLock
+# - renumberMesh
+
+
+class OpenFOAMProject(flow.FlowProject):
+    filtered_jobs: list[Job] = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def print_operations(self):
+        ops = sorted(self.groups.keys())
+        logging.info("Available operations are:\n\t" + "\n\t".join(ops))
+        return
+
+    def filter_jobs(self, filters: list[str]) -> list[Job]:
+        """`filter_jobs` accepts a list of filters.
+
+        The filters will be applied to all jobs inside the `OpenFOAMProject` instance and the filtered jobs will be returned as a list.
+        """
+        self.filtered_jobs = (
+            filter_jobs(self, filters) if filters else [j for j in self]
+        )
+        return self.filtered_jobs
+
+    def query(self, jobs: list[Job], query: list[Query]) -> list[dict]:
+        """return list of job ids as result of `Query`."""
+        return query_impl(jobs, query, output=True)
+
+    def set_entrypoint(self, entrypoint: dict):
+        """Sets the entrypoint for a project, this is useful for submit so that
+        submit writes scripts that call obr run -o <args> instead of the default signac run -o <args>
+        call
+        """
+        self._entrypoint = entrypoint
+
+
+generate = OpenFOAMProject.make_group(name="generate")
+simulate = OpenFOAMProject.make_group("execute")
+
+
+def is_case(job: Job) -> bool:
+    has_ctrlDict = job.isfile("case/system/controlDict")
+    return has_ctrlDict
+
+
+def is_job(job: Job) -> bool:
+    """checks OBR_JOB is set to the current job.id used to prevent multiple
+    execution of jobs if --job=id is set"""
+    skip_job = os.environ.get("OBR_JOB")
+    if skip_job and not str(job.id) == skip_job:
+        return False
+    return True
+
+
+def operation_complete(job: Job, operation: str) -> bool:
+    """An operation is considered to be complete if an entry in the job document with same arguments exists and state is success"""
+    if job.doc["state"].get("global") == "ready":
+        return True
+    else:
+        return False
+
+
+def basic_eligible(job: Job, operation: str) -> bool:
+    """Dispatches to standard checks if operations are eligible for given job
+
+    this includes:
+      - check for lock, to avoid running operations when calling 'obr run'
+        before operation is finished
+      - check if parent case is ready
+      - operation has been requested for job
+      - copy and link files and folder
+    """
+    # don't execute operation on cases that dont request them
+    initialize_if_required(job)
+    if (
+        is_locked(job)
+        or not operation == job.sp().get("operation")
+        or not parent_job_is_ready(job) == "ready"
+        or not is_case(job)
+    ):
+        # For Debug purposes
+        if False and (operation == job.sp().get("operation")):
+            logging.info(f"check if job {job.id} is eligible is False")
+            if is_locked(job):
+                logging.info(f"\tis_locked=True, should be False")
+            if not parent_job_is_ready(job) == "ready":
+                state = parent_job_is_ready(job)
+                logging.info(f"\tparent_job_is_ready={state} should be ready")
+            if not is_case(job):
+                logging.info("\tis_case=False should be True")
+        return False
+    return True
+
+
+def parent_job_is_ready(job: Job) -> str:
+    """Checks whether the parent of the given job is ready"""
+    if parent_id := job.sp().get("parent_id"):
+        project = OpenFOAMProject.get_project(path=job.path + "/../..")
+        with open(job.path + f"/../{parent_id}/signac_job_document.json", "r") as jh:
+            parent_job_dict = json.load(jh)
+            return parent_job_dict["state"].get("global", "")
+    return ""
+
+
+def _link_path(base: Path, dst: Path, copy_instead_link: bool):
+    """creates file tree under dst with same folder structure as base but all
+    files are relative symlinks
+    """
+    # ensure dst path exists
+    check_output(["mkdir", "-p", str(dst)])
+
+    # base path might not be ready atm
+    for root, folder, files in os.walk(Path(base)):
+        relative_path = Path(root).relative_to(base)
+
+        for fold in folder:
+            src = Path(root) / fold
+            dst_ = Path(dst) / relative_path / fold
+            if not dst_.exists():
+                check_output(
+                    [
+                        "mkdir",
+                        fold,
+                    ],
+                    cwd=dst / relative_path,
+                )
+
+        for fn in files:
+            src = Path(root) / fn
+            dst_ = Path(dst) / relative_path / fn
+            if not dst_.exists():
+                if copy_instead_link:
+                    check_output(
+                        [
+                            "cp",
+                            str(os.path.relpath(src, dst / relative_path)),
+                            ".",
+                        ],
+                        cwd=dst / relative_path,
+                    )
+
+                else:
+                    check_output(
+                        [
+                            "ln",
+                            "-s",
+                            str(os.path.relpath(src, dst / relative_path)),
+                        ],
+                        cwd=dst / relative_path,
+                    )
+
+
+def initialize_if_required(job: Job) -> bool:
+    """check if this job has been already linked to
+
+    The default strategy is to link all files. If a file is modified
+    the modifying operations are responsible for unlinking and copying
+    """
+    if parent_id := job.sp().get("parent_id"):
+        if job.doc["state"].get("is_initialized"):
+            return True
+        base_path = Path(job.path) / ".." / parent_id / "case"
+        dst_path = Path(job.path) / "case"
+        logging.debug(f"linking {base_path} to {dst_path}")
+
+        # shell scripts might change files as side effect hence we copy all files
+        # instead of linking to avoid side effects in future it might make sense to
+        # specify the files which are modified in the yaml file
+        copy_instead_link = job.sp().get("operation") == "shell"
+        _link_path(base_path, dst_path, copy_instead_link)
+        job.doc["state"]["is_initialized"] = True
+        return True
+    else:
+        return False
+
+
+def get_args(job: Job, args: Union[dict, str]) -> Union[dict, str]:
+    """operation can get args either via function call or it statepoint
+    if no args are passed via function the args from the statepoint are taken
+
+    also args can be just a str in case of shell scripts
+    """
+    if isinstance(args, dict):
+        return (
+            {key: value for key, value in args.items()}
+            if args
+            else {key: job.sp()[key] for key in job.sp().get("keys", [])}
+        )
+    else:
+        return args
+
+
+def execute_operation(job: Job, operation_name: str, operations) -> Literal[True]:
+    """check whether an operation is requested
+
+    operation can be simple operations defined by a keyword like blockMesh
+    or operations with parameters defined by a dictionary
+
+    """
+    if not operations:
+        return True
+    for operation in operations:
+        try:
+            if isinstance(operation, str):
+                getattr(sys.modules[__name__], operation)(job)
+            else:
+                func = list(operation.keys())[0]
+                getattr(sys.modules[__name__], func)(job, operation.get(func))
+        except Exception as e:
+            tb = traceback.format_exc()
+            logging.info(tb)
+            logging.error(e)
+            job.doc["state"]["global"] == "failure"
+    return True
+
+
+def execute_post_build(operation_name: str, job: Job):
+    """check whether an operation is requested
+
+    operation can be simple operations defined by a keyword like blockMesh
+    or operations with parameters defined by a dictionary
+    """
+    operations = job.sp.get("post_build", [])
+    execute_operation(job, operation_name, operations)
+
+
+def execute_pre_build(operation_name: str, job: Job):
+    """check whether an operation is requested
+
+    operation can be simple operations defined by a keyword like blockMesh
+    or operations with parameters defined by a dictionary
+    """
+    operations = job.sp.get("pre_build", [])
+    execute_operation(job, operation_name, operations)
+
+
+def start_job_state(_, job: Job) -> None:
+    current_state = job.doc["state"].get("global")
+    if not current_state:
+        job.doc["state"]["global"] = "started"
+    elif current_state == "started":
+        # job has been started but not finished yet
+        job.doc["state"]["global"] = "tmp_lock"
+
+
+def end_job_state(_, job: Job) -> Literal[True]:
+    job.doc["state"]["global"] = "ready"
+    return True
+
+
+def dispatch_pre_hooks(operation_name: str, job: Job):
+    """just forwards to start_job_state and execute_pre_build"""
+    start_job_state(operation_name, job)
+    execute_pre_build(operation_name, job)
+
+
+def dispatch_post_hooks(operation_name: str, job: Job):
+    """Forwards to `execute_post_build`, performs md5sum calculation of case files and finishes with `end_job_state`"""
+    execute_post_build(operation_name, job)
+    case = OpenFOAMCase(str(job.path) + "/case", job)
+    case.perform_post_md5sum_calculations()
+    end_job_state(operation_name, job)
+
+
+def set_failure(operation_name: str, error, job: Job):
+    """just forwards to start_job_state and execute_pre_build"""
+    job.doc["state"]["global"] = "failure"
+
+
+def copy_on_uses(args: dict, job: Job, path: str, target: str):
+    """copies the file specified in args['uses'] to path/target"""
+    if isinstance(args, str):
+        return
+    if uses := args.pop("uses", False):
+        if path:
+            check_output([
+                "cp",
+                "{}/case/{}/{}".format(job.path, path, uses),
+                "{}/case/{}/{}".format(job.path, path, target),
+            ])
+        else:
+            src_path = "{}/case/{}".format(job.path, uses)
+            trg_path = "{}/case/{}".format(job.path, target)
+            # It should be alright if the source path does not exists
+            # as long as the target path exists
+            if not Path(trg_path).exists() and Path(src_path).exists():
+                check_output(["cp", "-r", src_path, trg_path])
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "controlDict"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "controlDict"))
+@OpenFOAMProject.operation
+def controlDict(job: Job, args={}):
+    """sets up the controlDict"""
+    # TODO gets args either from function arguments if function
+    # was called directly from a pre/post build or from sp
+    # if this was a variation. In any case this could be a decorator
+    args = get_args(job, args)
+    copy_on_uses(args, job, "system", "controlDict")
+    OpenFOAMCase(str(job.path) + "/case", job).controlDict.set(args)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: job.sp().get("operation") == "MultiCase")
+@OpenFOAMProject.post(lambda job: operation_complete(job, "MultiCase"))
+@OpenFOAMProject.operation
+def MultiCase(job: Job, args={}):
+    """Dummy operation to generate multiple cases"""
+    args = get_args(job, args)
+    copy_on_uses(args, job, "system", "controlDict")
+    if not args.get("type"):
+        raise AssertionError(
+            "Please specify a type for the MultiCase. Valid types: GitRepo, CaseOnDisk,"
+            " OpenFOAMTutorialCase"
+        )
+    instantiate_origin_class(args["type"], args).init(job.path)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "blockMesh"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "blockMesh"))
+@OpenFOAMProject.operation
+def blockMesh(job: Job, args={}):
+    args = get_args(job, args)
+    OpenFOAMCase(str(job.path) + "/case", job).blockMesh(args)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "shell"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "shell"))
+@OpenFOAMProject.operation
+def shell(job: Job, args={}):
+    args = get_args(job, args)
+    # if called from post build args are just a string
+    if isinstance(args, dict):
+        steps = [f"{k} {v}".replace("_dot_", ".") for k, v in args.items()]
+    else:
+        steps = [args]
+    execute_shell(steps, job)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "zero"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "zero"))
+@OpenFOAMProject.operation
+def initialConditions(job: Job, args={}):
+    """A special operation to allow copying from 0.orig folders"""
+    args = get_args(job, args)
+    copy_on_uses(args, job, "", "0")
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "fvSolution"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "fvSolution"))
+@OpenFOAMProject.operation
+def fvSolution(job: Job, args={}):
+    args = get_args(job, args)
+    copy_on_uses(args, job, "system", "fvSolution")
+    if args:
+        OpenFOAMCase(str(job.path) + "/case", job).fvSolution.set(args)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "fvSchemes"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "fvSchemes"))
+@OpenFOAMProject.operation
+def fvSchemes(job: Job, args={}):
+    args = get_args(job, args)
+    copy_on_uses(args, job, "system", "fvSchemes")
+    if args:
+        OpenFOAMCase(str(job.path) + "/case", job).fvSchemes.set(args)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "transportProperties"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "transportProperties"))
+@OpenFOAMProject.operation
+def transportProperties(job: Job, args={}):
+    args = get_args(job, args)
+    copy_on_uses(args, job, "constant", "transportProperties")
+    if args:
+        OpenFOAMCase(str(job.path) + "/case", job).transportProperties.set(args)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "turbulenceProperties"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "turbulenceProperties"))
+@OpenFOAMProject.operation
+def turbulenceProperties(job: Job, args={}):
+    args = get_args(job, args)
+    copy_on_uses(args, job, "constant", "turbulenceProperties")
+    if args:
+        OpenFOAMCase(str(job.path) + "/case", job).turbulenceProperties.set(args)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "setKeyValuePair"))
+@OpenFOAMProject.post(lambda job: operation_complete(job, "setKeyValuePair"))
+@OpenFOAMProject.operation
+def setKeyValuePair(job: Job, args={}):
+    args = get_args(job, args)
+    OpenFOAMCase(str(job.path) + "/case", job).setKeyValuePair(args)
+
+
+def has_mesh(job: Job) -> bool:
+    """Check whether all mesh files are files (owning) or symlinks (non-owning)
+
+    TODO check also for .obr files for state of operation"""
+    fn = Path(job.path) / "case/constant/polyMesh"
+    if not fn.exists():
+        return False
+    for f in ["boundary", "faces", "neighbour", "owner", "points"]:
+        if not (fn / f).exists():
+            return False
+    return True
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "decomposePar"))
+@OpenFOAMProject.pre(has_mesh)
+@OpenFOAMProject.post(lambda job: operation_complete(job, "decomposePar"))
+@OpenFOAMProject.operation
+def decomposePar(job: Job, args={}):
+    args = get_args(job, args)
+
+    # NOTE don't try anything smart about reusing existing decompositions
+    # if decompositions should be reused place decompositions in front
+    # of your workflow file
+    workspace_folder = Path(job.path) / "../"
+    root, job_paths, _ = next(os.walk(workspace_folder))
+
+    target_case = OpenFOAMCase(str(job.path) + "/case", job)
+    target_case.decomposePar(args)
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: not bool(job.sp().get("parent_id")))
+@OpenFOAMProject.post(is_case)
+@OpenFOAMProject.operation
+def fetchCase(job: Job, args={}):
+    args = get_args(job, args)
+    if args["type"] == "MultiCase":
+        return
+
+    uses = args.pop("uses", [])
+    case_type = job.sp["type"]
+    fetch_case_handler = caseOrigins.instantiate_origin_class(case_type, args)
+    if fetch_case_handler is None:  # invalid type was specified in yaml
+        return
+    fetch_case_handler.init(path=job.path)
+
+    # if we find any entries in the list of 'uses' forward it to the
+    # corresponding operation. This means we call the corresponding operation
+    # with that specific value ie. uses: controlDict: controlDict.RANS will call
+    # the controlDict operation with  {uses: controlDict.RANS} as arguments
+    for entry in uses:
+        for k, v in entry.items():
+            getattr(sys.modules[__name__], k)(job, {"uses": v})
+
+
+def is_locked(job: Job) -> bool:
+    """Cases that are already started are set to tmp_lock
+    dont try to execute them
+    """
+    return job.doc["state"].get("global") == "tmp_lock"
+
+
+@generate
+@OpenFOAMProject.operation_hooks.on_start(dispatch_pre_hooks)
+@OpenFOAMProject.operation_hooks.on_success(dispatch_post_hooks)
+@OpenFOAMProject.operation_hooks.on_exception(set_failure)
+@OpenFOAMProject.pre(lambda job: basic_eligible(job, "refineMesh"))
+@OpenFOAMProject.pre(has_mesh)
+@OpenFOAMProject.post(lambda job: operation_complete(job, "refineMesh"))
+@OpenFOAMProject.operation
+def refineMesh(job: Job, args={}):
+    args = get_args(job, args)
+    for _ in range(args.get("value")):
+        OpenFOAMCase(str(job.path) + "/case", job).refineMesh(args)
+
+
+@OpenFOAMProject.pre(parent_job_is_ready)
+@OpenFOAMProject.pre(owns_mesh)
+@OpenFOAMProject.operation
+def allClean(job: Job, args={}):
+    args = get_args(job, args)
+    allCleanPath = Path(job.path) / "case/Allclean"
+    if allCleanPath.exists():
+        check_output(["./Allclean"], cwd=str(job.path) + "/case")
+
+
+@OpenFOAMProject.pre(parent_job_is_ready)
+@OpenFOAMProject.pre(owns_mesh)
+@OpenFOAMProject.operation
+def checkMesh(job: Job, args={}):
+    args = get_args(job, args)
+    log = OpenFOAMCase(str(job.path) + "/case", job).checkMesh(args)
+
+    cells = (
+        check_output(["grep", "cells:", Path(job.path) / "case" / log])
+        .decode("utf-8")
+        .split()[-1]
+    )
+    job.doc["cache"]["nCells"] = int(cells)
+
+
+def get_number_of_procs(job: Job) -> int:
+    """Deduces the number of processors
+    For performance reasons the cache is used to store the number of subdomains
+    """
+    np = statepoint_get(job.sp(), "numberOfSubdomains")
+    if np:
+        return int(np)
+    np = job.doc["cache"].get("numberOfSubdomains", False)
+    if np:
+        return int(np)
+    # Reading from numberOfSubdomains from the decomposeParDict should
+    # be the last resort since it is very expensive
+    np = int(
+        OpenFOAMCase(str(job.path) + "/case", job).decomposeParDict.get(
+            "numberOfSubdomains"
+        )
+    )
+    if np:
+        job.doc["cache"]["numberOfSubdomains"] = np
+    return np
+
+
+def get_values(jobs: list, key: str) -> set:
+    """find all different statepoint values"""
+    values = [job.sp().get(key) for job in jobs if job.sp().get(key)]
+    return set(values)
+
+
+def run_cmd_builder(job: Job, cmd_format: str, args: dict) -> str:
+    """Builds the cli command to run a OpenFOAM application"""
+
+    skip_complete = os.environ.get("OBR_SKIP_COMPLETE")
+    if skip_complete and finished(job):
+        logging.info(f"Skipping Job {job.id} since it is completed.")
+        return "true"
+
+    case = OpenFOAMCase(str(job.path) + "/case", job)
+
+    # if the case folder contains any modified files skip execution
+    if case.is_tree_modified():
+        logging.info(f"Skipping Job {job.id} since it is has modified files.")
+        job.doc["state"]["global"] = "dirty"
+        return "true"
+
+    solver = case.controlDict.get("application")
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
+
+    res = job.doc["history"]
+
+    cli_args = {
+        "solver": solver,
+        "path": job.path,
+        "timestamp": timestamp,
+        "np": get_number_of_procs(job),
+    }
+    cmd_str = cmd_format.format(**cli_args)
+    res.append({
+        "cmd": cmd_str,
+        "type": "shell",
+        "log": f"{solver}_{timestamp}.log",
+        "state": "started",
+        "timestamp": timestamp,
+        "user": os.environ.get("USER"),
+        "hostname": os.environ.get("HOST"),
+    })
+    job.doc["history"] = res
+
+    cli_args = {
+        "solver": solver,
+        "path": job.path,
+        "timestamp": timestamp,
+        "np": get_number_of_procs(job),
+    }
+    preflight = os.environ.get("OBR_PREFLIGHT")
+    if preflight:
+        preflight_cmd = f"{preflight} > {job.path}/case/preflight_{timestamp}.log && "
+        cmd_format = preflight_cmd + cmd_format
+
+    postflight_cmd = f" && echo $? > {job.path}/case/solverExitCode.log "
+
+    job.doc["state"]["global"] = "started"
+
+    # NOTE we add || true such that the command never fails
+    # otherwise if one execution would fail OBR exits and
+    # the following solver runs would be discarded
+    return cmd_format.format(**cli_args) + "|| true" + postflight_cmd
+
+
+def validate_state_impl(_: str, job: Job) -> None:
+    """Perform a detailed update of the job state"""
+    case = OpenFOAMCase(Path(job.path) / "case", job)
+    case.detailed_update()
+
+
+@OpenFOAMProject.pre(parent_job_is_ready)
+@OpenFOAMProject.pre(final)
+@OpenFOAMProject.pre(is_job)
+@OpenFOAMProject.operation
+def validateState(job: Job, args={}) -> None:
+    """Dummy operation which forwards to validate_state_impl. The reason for keeping this function
+    is that it can be called from the cli to force a detailed update"""
+    validate_state_impl(job)
+
+
+@simulate
+@OpenFOAMProject.pre(final)
+@OpenFOAMProject.pre(is_job)
+@OpenFOAMProject.operation(
+    cmd=True, directives={"np": lambda job: get_number_of_procs(job)}
+)
+@OpenFOAMProject.operation_hooks.on_exit(validate_state_impl)
+def runParallelSolver(job: Job, args={}) -> str:
+    env_run_template = os.environ.get("OBR_RUN_CMD")
+    solver_cmd = (
+        env_run_template
+        if env_run_template
+        else (
+            "mpirun -np {np} {solver} -case {path}/case >"
+            " {path}/case/{solver}_{timestamp}.log 2>&1"
+        )
+    )
+    return run_cmd_builder(job, solver_cmd, args)
+
+
+@simulate
+@OpenFOAMProject.pre(final)
+@OpenFOAMProject.pre(is_job)
+@OpenFOAMProject.operation(cmd=True)
+@OpenFOAMProject.operation_hooks.on_exit(validate_state_impl)
+def runSerialSolver(job: Job, args={}):
+    env_run_template = os.environ.get("OBR_SERIAL_RUN_CMD")
+    solver_cmd = (
+        env_run_template
+        if env_run_template
+        else "{solver} -case {path}/case > {path}/case/{solver}_{timestamp}.log 2>&1"
+    )
+    return run_cmd_builder(job, solver_cmd, args)
+
+
+@OpenFOAMProject.operation
+def archive(job: Job, args={}) -> Literal[True]:
+    root, _, files = next(os.walk(Path(job.path) / "case"))
+    fp = os.environ.get("OBR_CALL_ARGS", "")
+    for fn in files:
+        if fp not in fn:
+            continue
+        if (Path(root) / fn).is_symlink():
+            continue
+        check_output(["cp", "-r", f"{job.path}/case/{fn}", f"obr_store/{job.id}_{fn}"])
+    return True
+
+
+@OpenFOAMProject.operation(aggregator=flow.aggregator())
+def apply(*jobs, args={}):
+    import importlib.util
+
+    fp = Path(os.environ.get("OBR_CALL_ARGS"))
+    spec = importlib.util.spec_from_file_location("apply_func", fp)
+    apply_functor = importlib.util.module_from_spec(spec)
+    # sys.modules["apply_func"] = apply_functor
+    spec.loader.exec_module(apply_functor)
+    apply_functor.call(jobs)

--- a/src/obr/signac_wrapper/submit.py
+++ b/src/obr/signac_wrapper/submit.py
@@ -21,6 +21,7 @@ def submit_impl(
     pretend: bool,
     bundling_key: Union[str, None],
     scheduler_args: str,
+    skip_eligible_check = False
 ):
     template_target_path = Path(project.path) / "templates/script.sh"
     template_src_path = Path(template)
@@ -72,7 +73,6 @@ def submit_impl(
             time.sleep(15)
     else:
         eligible_jobs = []
-
         for operation in operations:
             logging.info(f"Collecting eligible jobs for operation: {operation}.")
             for job in tqdm(jobs):
@@ -85,7 +85,7 @@ def submit_impl(
             f" {[j.id for j in eligible_jobs]}"
         )
         ret_submit = project.submit(
-            jobs=eligible_jobs,
+            jobs=eligible_jobs if not skip_eligible_check else jobs,
             names=operations,
             **cluster_args,
         )

--- a/src/obr/signac_wrapper/submit.py
+++ b/src/obr/signac_wrapper/submit.py
@@ -21,7 +21,7 @@ def submit_impl(
     pretend: bool,
     bundling_key: Union[str, None],
     scheduler_args: str,
-    skip_eligible_check = False
+    skip_eligible_check=False,
 ):
     template_target_path = Path(project.path) / "templates/script.sh"
     template_src_path = Path(template)

--- a/src/obr/signac_wrapper/submit.py
+++ b/src/obr/signac_wrapper/submit.py
@@ -43,7 +43,7 @@ def submit_impl(
         "partition": partition,
         "pretend": pretend,
         "account": account,
-        "walltime": time
+        "walltime": time,
     }
 
     # TODO improve this using regex
@@ -71,7 +71,7 @@ def submit_impl(
             logging.info("Submission response" + str(ret_submit))
             time.sleep(15)
     else:
-        eligible_jobs =  []
+        eligible_jobs = []
 
         for operation in operations:
             logging.info(f"Collecting eligible jobs for operation: {operation}.")
@@ -79,7 +79,11 @@ def submit_impl(
                 if basic_eligible(job, operation):
                     eligible_jobs.append(job)
 
-        logging.info(f"Submitting operations {operations}. In total {len(eligible_jobs)} of {len(jobs)} individual jobs.\nEligible jobs {[j.id for j in eligible_jobs]}")
+        logging.info(
+            f"Submitting operations {operations}. In total {len(eligible_jobs)} of"
+            f" {len(jobs)} individual jobs.\nEligible jobs"
+            f" {[j.id for j in eligible_jobs]}"
+        )
         ret_submit = project.submit(
             jobs=eligible_jobs,
             names=operations,

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -10,7 +10,7 @@ def test_link_path(tmpdir):
     check_output(["mkdir", "src/fold1"], cwd=tmpdir)
     check_output(["touch", "src/fold1/file2"], cwd=tmpdir)
 
-    _link_path(tmpdir / "src", tmpdir / "dst", copy_instead_link=False)
+    _link_path(tmpdir / "src", tmpdir / "dst", "", copy_instead_link=False)
 
     dst = Path(tmpdir) / "dst"
 

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -107,6 +107,7 @@ def test_submit(tmpdir):
                 pretend=True,
                 bundling_key=None,
                 scheduler_args="",
+                skip_eligible_check=True,
             )
 
     templates_dir = tmpdir / "templates"
@@ -117,5 +118,4 @@ def test_submit(tmpdir):
         assert "test_token" in submit_log
         assert "--account=account" in submit_log
         assert "--partition=partition" in submit_log
-        assert "#SBATCH -t 60" in submit_log
         assert "--mem=" not in submit_log

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -103,6 +103,7 @@ def test_submit(tmpdir):
                 template=tmpdir / "local.sh",
                 account=account,
                 partition=partition,
+                time="60",
                 pretend=True,
                 bundling_key=None,
                 scheduler_args="",

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -88,7 +88,7 @@ def test_submit(tmpdir):
             template=tmpdir / "does_not_exists.sh",
             account=account,
             partition=partition,
-            time="60"
+            time="60",
             pretend=True,
             bundling_key=None,
             scheduler_args="",

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -88,6 +88,7 @@ def test_submit(tmpdir):
             template=tmpdir / "does_not_exists.sh",
             account=account,
             partition=partition,
+            time="60"
             pretend=True,
             bundling_key=None,
             scheduler_args="",
@@ -115,4 +116,5 @@ def test_submit(tmpdir):
         assert "test_token" in submit_log
         assert "--account=account" in submit_log
         assert "--partition=partition" in submit_log
+        assert "#SBATCH -t 60" in submit_log
         assert "--mem=" not in submit_log


### PR DESCRIPTION
This PR improves the output of `obr submit` by displaying the number of eligible jobs and printing the job.ids of the submitted jobs. It adds a progress bar to show that submit is not hanging.
Additionally, it adds a missing time argument.

**Note** For performance reasons this PR also changes the initialization of the cases. Now processor contents are copied directly by default and only the `processor*/constant` folder gets symlinked. This allows skipping costly traversal of all `processor*/timestep` folders. However, this will increase the resulting case size and we should at some point introduce the option to link.