### PR TITLE
Improve logging output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,11 +19,12 @@ Changelog
 - Add statepoint dependant filter for create_tree, see https://github.com/hpsim/OBR/pull/187
 - Add 'obr apply' mode, see https://github.com/hpsim/OBR/pull/188
 - Add 'obr --version', see https://github.com/hpsim/OBR/pull/188
-- Add template block generators, see https://github.com/hpsim/OBR/pull/18://github.com/hpsim/OBR/pull/190 
-- Add 'validateState' operation, see https://github.com/hpsim/OBR/pull/189 
-- Improve 'run*Solver' launch speed, see https://github.com/hpsim/OBR/pull/189 
+- Add template block generators, see https://github.com/hpsim/OBR/pull/18://github.com/hpsim/OBR/pull/190
+- Add 'validateState' operation, see https://github.com/hpsim/OBR/pull/189
+- Improve 'run*Solver' launch speed, see https://github.com/hpsim/OBR/pull/189
 - Add '--generate' flag to 'obr init', see https://github.com/hpsim/OBR/pull/191
 - Add 'obr reset' mode, see https://github.com/hpsim/OBR/pull/192
+- Improve cli output, https://github.com/hpsim/OBR/pull/198
 
 
 0.2.0 (2023-09-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obr"
-version = "0.3.15"
+version = "0.3.16"
 description = "A tool to create and run OpenFOAM parameter studies"
 authors = [
     {name = "Gregor Olenik", email = "go@hpsim.de"},
@@ -23,6 +23,7 @@ dependencies = [
     "pandas",
     "DeepDiff",
     "jsonschema==4.19.1",
+    "colorlogs",
     "Owls @ git+https://github.com/greole/Owls.git@Owls2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pandas",
     "DeepDiff",
     "jsonschema==4.19.1",
-    "colorlogs",
+    "coloredlogs",
     "Owls @ git+https://github.com/greole/Owls.git@Owls2.0",
 ]
 

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -21,6 +21,7 @@ import os
 import sys
 import logging
 import shutil
+import functools
 
 from signac.job import Job
 from pathlib import Path
@@ -39,6 +40,15 @@ from .core.parse_yaml import read_yaml
 from .cli_impl import query_impl
 from .core.core import map_view_folder_to_job_id, profile_call
 
+
+def common_params(func):
+    @click.option('--debug')
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if kwargs.get("debug"):
+            print("in debug mode")
+        return func(*args, **kwargs)
+    return wrapper
 
 def check_cli_operations(
     project: OpenFOAMProject, operations: list[str], list_operations: Optional[Any]
@@ -209,6 +219,7 @@ def submit(ctx: click.Context, **kwargs):
 
 
 @cli.command()
+@common_params
 @click.option("-f", "--folder", default=".")
 @click.option(
     "-o",

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -39,9 +39,7 @@ from .create_tree import create_tree
 from .core.parse_yaml import read_yaml
 from .cli_impl import query_impl
 from .core.core import map_view_folder_to_job_id, profile_call
-from .core.logger_setup import setup_logging
-
-logger = logging.getLogger("OBR")
+from .core.logger_setup import logger, setup_logging
 
 def common_params(func):
     @click.option(
@@ -328,7 +326,7 @@ def run(ctx: click.Context, **kwargs):
     else:
         # calling for aggregates does not work with jobs
         profile_call(project.run, names=operations, np=kwargs.get("tasks", -1))
-    logger.info("completed all operations")
+    logger.success("Completed all operations")
 
 
 @cli.command()
@@ -353,7 +351,7 @@ def init(ctx: click.Context, **kwargs):
     project = OpenFOAMProject.init_project(path=kwargs["folder"])
     create_tree(project, config, kwargs)
 
-    logger.info("successfully initialised")
+    logger.success("Successfully initialised")
 
     if kwargs.get("generate"):
         logger.info("Generating workspace")
@@ -488,6 +486,7 @@ def apply(ctx: click.Context, **kwargs):
         progress=True,
         np=1,
     )
+    logger.success("Successfully applied")
 
 
 @cli.command()
@@ -548,6 +547,7 @@ def reset(ctx: click.Context, **kwargs):
 
     if kwargs.get("view"):
         logger.error("Resetting by view path is not yet supported")
+    logger.success("Successfully reseted")
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -155,8 +155,6 @@ def copy_to_archive(
 def cli(ctx: click.Context, **kwargs):
     # ensure that ctx.obj exists and is a dict (in case `cli()` is called
     # by means other than the `if` block below)
-    if kwargs.get("version"):
-        print("obr version")
     ctx.ensure_object(dict)
     ctx.obj["DEBUG"] = kwargs.get("debug")
 

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -571,7 +571,7 @@ def reset(ctx: click.Context, **kwargs):
 
     if kwargs.get("view"):
         logger.error("Resetting by view path is not yet supported")
-    logger.success("Successfully reseted")
+    logger.success("Reset successful")
 
 
 @cli.command()

--- a/src/obr/cli.py
+++ b/src/obr/cli.py
@@ -41,6 +41,7 @@ from .cli_impl import query_impl
 from .core.core import map_view_folder_to_job_id, profile_call
 from .core.logger_setup import logger, setup_logging
 
+
 def common_params(func):
     @click.option(
         "--debug", is_flag=True, help="Increase verbosity of the output to debug mode"
@@ -351,7 +352,7 @@ def init(ctx: click.Context, **kwargs):
     # needs folder/.obr to exists before logger can be initialised
     ws_fold = kwargs.get("folder")
     if ws_fold:
-        (Path(ws_fold) /".obr").mkdir(parents=True, exist_ok=True)
+        (Path(ws_fold) / ".obr").mkdir(parents=True, exist_ok=True)
     else:
         Path(".obr").mkdir(parents=True, exist_ok=True)
     setup_logging(log_fold=ws_fold)
@@ -533,7 +534,7 @@ def reset(ctx: click.Context, **kwargs):
 
     project, jobs = cli_cmd_setup(kwargs)
 
-    confirmed = kwargs.get("y",False)
+    confirmed = kwargs.get("y", False)
     if kwargs.get("workspace"):
         logger.warn(
             f"Removing current obr workspace. This will remove all simulation results"

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -50,7 +50,7 @@ def query_impl(
                 difference_dict = DeepDiff(validation_dict, query_results)
 
                 if difference_dict:
-                    print(difference_dict)
                     logger.warn("Validation failed!")
+                    logger.warn(difference_dict)
                     sys.exit(1)
             logger.success("Validation successful")

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -51,4 +51,4 @@ def query_impl(
                     print(difference_dict)
                     logging.warn("Validation failed!")
                     sys.exit(1)
-                logging.info("Validation successful")
+            logging.info("Validation successful")

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -52,4 +52,4 @@ def query_impl(
                     print(difference_dict)
                     logger.warn("Validation failed!")
                     sys.exit(1)
-            logger.info("Validation successful")
+            logger.success("Validation successful")

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from .signac_wrapper.operations import OpenFOAMProject
 from .core.queries import build_filter_query
 
+logger = logging.getLogger("OBR")
 
 def query_impl(
     project: OpenFOAMProject,
@@ -16,7 +17,7 @@ def query_impl(
     validation_file: str,
 ):
     if input_queries == "":
-        logging.warning("--query argument cannot be empty!")
+        logger.warning("--query argument cannot be empty!")
         return
     queries: list[Query] = build_filter_query(input_queries)
     jobs = project.filter_jobs(filters=list(filters))
@@ -26,7 +27,7 @@ def query_impl(
             out_str = f"{job_id}:"
             for k, v in query_res.items():
                 out_str += f" {k}: {v}"
-            logging.info(out_str)
+            logger.info(out_str)
 
     if json_file:
         with open(json_file, "w") as outfile:
@@ -37,18 +38,18 @@ def query_impl(
             # json_data refers to the above JSON
             validation_dict = json.load(infile)
             if validation_dict.get("$schema"):
-                logging.info("Using json schema for validation")
+                logger.info("Using json schema for validation")
                 from jsonschema import validate
 
                 validate(query_results, validation_dict)
             else:
                 from deepdiff import DeepDiff
 
-                logging.info("Using deepdiff for validation")
+                logger.info("Using deepdiff for validation")
                 difference_dict = DeepDiff(validation_dict, query_results)
 
                 if difference_dict:
                     print(difference_dict)
-                    logging.warn("Validation failed!")
+                    logger.warn("Validation failed!")
                     sys.exit(1)
-            logging.info("Validation successful")
+            logger.info("Validation successful")

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -8,6 +8,7 @@ from .core.queries import build_filter_query
 
 logger = logging.getLogger("OBR")
 
+
 def query_impl(
     project: OpenFOAMProject,
     input_queries: tuple[str],

--- a/src/obr/cli_impl.py
+++ b/src/obr/cli_impl.py
@@ -37,17 +37,18 @@ def query_impl(
             # json_data refers to the above JSON
             validation_dict = json.load(infile)
             if validation_dict.get("$schema"):
-                logging.info("using json schema for validation")
+                logging.info("Using json schema for validation")
                 from jsonschema import validate
 
                 validate(query_results, validation_dict)
             else:
                 from deepdiff import DeepDiff
 
-                logging.info("using deepdiff for validation")
+                logging.info("Using deepdiff for validation")
                 difference_dict = DeepDiff(validation_dict, query_results)
 
                 if difference_dict:
                     print(difference_dict)
-                    logging.warn("validation failed")
+                    logging.warn("Validation failed!")
                     sys.exit(1)
+                logging.info("Validation successful")

--- a/src/obr/core/caseOrigins.py
+++ b/src/obr/core/caseOrigins.py
@@ -1,11 +1,14 @@
+import logging
+import shutil
+
 from os import environ
 from os.path import expandvars, isdir
-from distutils.dir_util import copy_tree
 from pathlib import Path
 from typing import Union
 from subprocess import check_output
-import logging
 from git.repo import Repo
+
+logger = logging.getLogger("OBR")
 
 
 class MultiCase:
@@ -18,7 +21,7 @@ class MultiCase:
 
     def init(self, path):
         if not isdir(self.path):
-            logging.warning(
+            logger.warning(
                 f"{self.path.absolute} or some parent directory does not exist!"
             )
             return
@@ -35,13 +38,17 @@ class CaseOnDisk:
             origin = expandvars(origin)
         self.path = Path(origin).expanduser()
 
-    def init(self, path):
+    def init(self, path:str):
         if not isdir(self.path):
-            logging.warning(
+            logger.warning(
                 f"{self.path.absolute} or some parent directory does not exist!"
             )
             return
-        copy_tree(str(self.path), str(Path(path) / "case"))
+
+
+        dst = Path(path)/"case"
+        logger.debug(f"copying {self.path} to {dst}")
+        shutil.copytree(src=f"{str(self.path)}", dst=f"{str(dst)}")
 
 
 class OpenFOAMTutorialCase(CaseOnDisk):

--- a/src/obr/core/caseOrigins.py
+++ b/src/obr/core/caseOrigins.py
@@ -38,15 +38,14 @@ class CaseOnDisk:
             origin = expandvars(origin)
         self.path = Path(origin).expanduser()
 
-    def init(self, path:str):
+    def init(self, path: str):
         if not isdir(self.path):
             logger.warning(
                 f"{self.path.absolute} or some parent directory does not exist!"
             )
             return
 
-
-        dst = Path(path)/"case"
+        dst = Path(path) / "case"
         logger.debug(f"copying {self.path} to {dst}")
         shutil.copytree(src=f"{str(self.path)}", dst=f"{str(dst)}")
 

--- a/src/obr/core/logger_setup.py
+++ b/src/obr/core/logger_setup.py
@@ -1,0 +1,70 @@
+import logging
+
+# class CustomFormatter(logging.Formatter):
+#
+#     # log formating stuff
+#     grey = "\x1b[38;20m"
+#     yellow = "\x1b[33;20m"
+#     red = "\x1b[31;20m"
+#     bold_red = "\x1b[31;1m"
+#     reset = "\x1b[0m"
+#     format="%(message)-150s [OBR %(levelname)s, %(filename)s:%(lineno)d]"
+#
+#     FORMATS = {
+#         logging.DEBUG: grey + format + reset,
+#         logging.INFO: grey + format + reset,
+#         logging.WARNING: yellow + format + reset,
+#         logging.ERROR: red + format + reset,
+#         logging.CRITICAL: bold_red + format + reset
+#     }
+#
+#     def format(self, record):
+#         log_fmt = self.FORMATS.get(record.levelno)
+#         formatter = logging.Formatter(log_fmt)
+#         return formatter.format(record)
+
+
+def setup_logging():
+    grey = "\x1b[38;20m"
+    yellow = "\x1b[33;20m"
+    red = "\x1b[31;20m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
+
+    config_dict = {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "colored_console": {
+                "()": "coloredlogs.ColoredFormatter",
+                "format": " %(name)s: %(message)s",
+                "datefmt": "%H:%M:%S",
+            },
+            "detailed": {
+                "format": (
+                    "[OBR] %(message)-150s [OBR %(levelname)s, %(filename)s:%(lineno)d]"
+                )
+            },
+        },
+        "handlers": {
+            "stdout_simple": {
+                "level": "INFO",
+                "class": "logging.StreamHandler",
+                "formatter": "colored_console",
+                "stream": "ext://sys.stdout",
+            },
+            "file_detailed": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "level": "DEBUG",
+                "formatter": "detailed",
+                "filename": ".obr/obr.log",
+                "maxBytes": 10000,
+                "backupCount": 3,
+            },
+        },
+        "loggers": {
+            "OBR": {"level": "INFO", "handlers": ["stdout_simple", "file_detailed"]}
+        },
+    }
+
+    logging.config.dictConfig(config=config_dict)

--- a/src/obr/core/logger_setup.py
+++ b/src/obr/core/logger_setup.py
@@ -1,28 +1,14 @@
 import logging
 
-# class CustomFormatter(logging.Formatter):
-#
-#     # log formating stuff
-#     grey = "\x1b[38;20m"
-#     yellow = "\x1b[33;20m"
-#     red = "\x1b[31;20m"
-#     bold_red = "\x1b[31;1m"
-#     reset = "\x1b[0m"
-#     format="%(message)-150s [OBR %(levelname)s, %(filename)s:%(lineno)d]"
-#
-#     FORMATS = {
-#         logging.DEBUG: grey + format + reset,
-#         logging.INFO: grey + format + reset,
-#         logging.WARNING: yellow + format + reset,
-#         logging.ERROR: red + format + reset,
-#         logging.CRITICAL: bold_red + format + reset
-#     }
-#
-#     def format(self, record):
-#         log_fmt = self.FORMATS.get(record.levelno)
-#         formatter = logging.Formatter(log_fmt)
-#         return formatter.format(record)
+logger = logging.getLogger("OBR")
 
+
+SUCCESS_LEVELV_NUM = 25
+logging.addLevelName(SUCCESS_LEVELV_NUM, "SUCCESS")
+def success(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    self._log(SUCCESS_LEVELV_NUM, message, args, **kws)
+logging.Logger.success = success
 
 def setup_logging():
     grey = "\x1b[38;20m"

--- a/src/obr/core/logger_setup.py
+++ b/src/obr/core/logger_setup.py
@@ -1,4 +1,5 @@
 import logging
+import logging.config
 
 logger = logging.getLogger("OBR")
 

--- a/src/obr/core/logger_setup.py
+++ b/src/obr/core/logger_setup.py
@@ -5,10 +5,15 @@ logger = logging.getLogger("OBR")
 
 SUCCESS_LEVELV_NUM = 25
 logging.addLevelName(SUCCESS_LEVELV_NUM, "SUCCESS")
+
+
 def success(self, message, *args, **kws):
     # Yes, logger takes its '*args' as 'args'.
     self._log(SUCCESS_LEVELV_NUM, message, args, **kws)
+
+
 logging.Logger.success = success
+
 
 def setup_logging(log_fold=""):
     grey = "\x1b[38;20m"

--- a/src/obr/core/logger_setup.py
+++ b/src/obr/core/logger_setup.py
@@ -10,12 +10,14 @@ def success(self, message, *args, **kws):
     self._log(SUCCESS_LEVELV_NUM, message, args, **kws)
 logging.Logger.success = success
 
-def setup_logging():
+def setup_logging(log_fold=""):
     grey = "\x1b[38;20m"
     yellow = "\x1b[33;20m"
     red = "\x1b[31;20m"
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
+
+    log_fold = log_fold + "/" if log_fold else log_fold
 
     config_dict = {
         "version": 1,
@@ -43,7 +45,7 @@ def setup_logging():
                 "class": "logging.handlers.RotatingFileHandler",
                 "level": "DEBUG",
                 "formatter": "detailed",
-                "filename": ".obr/obr.log",
+                "filename": f"{log_fold}.obr/obr.log",
                 "maxBytes": 10000,
                 "backupCount": 3,
             },

--- a/src/obr/core/parse_yaml.py
+++ b/src/obr/core/parse_yaml.py
@@ -2,8 +2,9 @@ import re
 import os
 import urllib.request
 from pathlib import Path
-import logging
 import sys
+
+from .logger_setup import logger
 
 
 def read_yaml(kwargs: dict) -> str:
@@ -49,7 +50,7 @@ def parse_special_variables(in_str: str, args: dict, domain: str) -> str:
     ocurrances = re.findall(r"\${{" + domain + r"\.(\w+)}}", in_str)
     for inst in ocurrances:
         if not args.get(inst, ""):
-            logging.warning(f"warning {inst} not defined")
+            logger.warning(f"warning {inst} not defined")
         in_str = in_str.replace(
             "${{" + domain + "." + inst + "}}", args.get(inst, f"'{inst}'")
         )
@@ -63,8 +64,8 @@ def eval_generator_expressions(in_str: str) -> str:
         try:
             in_str = in_str.replace("${{" + inst + "}}", str(eval(inst)))
         except Exception as e:
-            logging.error(in_str + inst)
-            logging.error(e)
+            logger.error(in_str + inst)
+            logger.error(e)
 
             sys.exit(1)
     return in_str

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("OBR")
 
+
 @dataclass
 class query_result:
     id: str = field()

--- a/src/obr/core/queries.py
+++ b/src/obr/core/queries.py
@@ -12,6 +12,7 @@ from enum import Enum
 if TYPE_CHECKING:
     from obr.signac_wrapper.operations import OpenFOAMProject
 
+logger = logging.getLogger("OBR")
 
 @dataclass
 class query_result:
@@ -83,15 +84,15 @@ class Query:
                 self.state = {key: value}
         except TypeError as e:
             # After the prior type conversion, this case should not happen anymore.
-            logging.error(f"{e}:")
-            logging.error(
+            logger.error(f"{e}:")
+            logger.error(
                 f"\tTried to compare {self.value}({type(self.value)}) and"
                 f" {value}({type(value)}) for {key=}."
             )
         except ValueError as e:
             # In case of a funky type conversion. Not expected behavior though.
-            logging.info(value)
-            logging.error(e)
+            logger.warning(value)
+            logger.error(e)
 
     def match(self):
         return self.state
@@ -307,12 +308,12 @@ def build_filter_query(filters: Iterable[str]) -> list[Query]:
         for predicate in Predicates:
             # check if predicates like =, >, <=.. are in the filter
             if predicate.value in filter:
-                logging.info(f"Found predicate {predicate} in {filter=}")
+                logger.debug(f"Found predicate {predicate} in {filter=}")
                 lhs, rhs = filter.split(predicate.value)
                 q.append(Query(key=lhs, value=rhs, predicate=predicate.name))
                 break
         else:
-            logging.warning(
+            logger.debug(
                 f"No applicable predicate found in {filter=}. Will assume '!= None'."
             )
             q.append(Query(key=filter, value=None, predicate=Predicates.neq.name))

--- a/src/obr/create_tree.py
+++ b/src/obr/create_tree.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import logging
 
 from collections.abc import MutableMapping
 from pathlib import Path
@@ -9,6 +8,7 @@ from signac.job import Job
 from obr.signac_wrapper.operations import OpenFOAMProject
 from obr.core.queries import statepoint_query
 from obr.core.parse_yaml import eval_generator_expressions
+from obr.core.logger_setup import logger
 from copy import deepcopy
 
 
@@ -29,7 +29,7 @@ def get_path_from(operation: dict, value: dict) -> str:
     Returns: a view path as string
     """
     if not operation.get("schema"):
-        logging.error("Error Schema missing for Set schema to allow creating views")
+        logger.error("Error Schema missing for Set schema to allow creating views")
         raise KeyError
 
     return operation["schema"].format(**flatten(value)) + "/"
@@ -247,7 +247,7 @@ def add_variations(
                     key, value = list(filter_record.items())[0]
                     skip = not statepoint_query(statepoint, key, value, predicate)
                     if skip:
-                        logging.debug(
+                        logger.debug(
                             f"skipping generating statepoint {statepoint} because of"
                             f" {key}=={value} filter"
                         )
@@ -293,7 +293,7 @@ def create_tree(
     skip_foam_src_check: bool = False,
 ):
     if not skip_foam_src_check and not os.environ.get("FOAM_ETC"):
-        logging.error("Error OpenFOAM not sourced")
+        logger.error("Error OpenFOAM not sourced")
         sys.exit(-1)
 
     # Add base case

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -20,12 +20,7 @@ from obr.OpenFOAM.case import OpenFOAMCase
 from obr.core.queries import filter_jobs, query_impl, Query, statepoint_get
 from obr.core.caseOrigins import instantiate_origin_class
 
-# TODO operations should get an id/hash so that we can log success
-# TODO add:
-# - reconstructPar
-# - unlockTmpLock
-# - renumberMesh
-
+logger = logging.getLogger("OBR")
 
 class OpenFOAMProject(flow.FlowProject):
     filtered_jobs: list[Job] = []
@@ -35,7 +30,7 @@ class OpenFOAMProject(flow.FlowProject):
 
     def print_operations(self):
         ops = sorted(self.groups.keys())
-        logging.info("Available operations are:\n\t" + "\n\t".join(ops))
+        logger.info("Available operations are:\n\t" + "\n\t".join(ops))
         return
 
     def filter_jobs(self, filters: list[str]) -> list[Job]:
@@ -108,16 +103,16 @@ def basic_eligible(job: Job, operation: str) -> bool:
     ):
         # For Debug purposes
         if False and (operation == job.sp().get("operation")):
-            logging.info(f"check if job {job.id} is eligible is False")
+            logger.info(f"check if job {job.id} is eligible is False")
             if is_locked(job):
-                logging.info(f"\tis_locked=True, should be False")
+                logger.info(f"\tis_locked=True, should be False")
             if not parent_job_is_ready(job) == "ready":
                 state = parent_job_is_ready(job)
-                logging.info(f"\tparent_job_is_ready={state} should be ready")
+                logger.info(f"\tparent_job_is_ready={state} should be ready")
             if not initialize_if_required(job):
-                logging.info(f"\tinitialize_if_required=False should be True")
+                logger.info(f"\tinitialize_if_required=False should be True")
             if not is_case(job):
-                logging.info("\tis_case=False should be True")
+                logger.info("\tis_case=False should be True")
         return False
     return True
 
@@ -235,7 +230,7 @@ def initialize_if_required(job: Job) -> bool:
         GLOBAL_INIT_COUNT += 1
         base_path = Path(job.path).parent / parent_id / "case"
         dst_path = Path(job.path) / "case"
-        # logging.info(f"linking {base_path} to {dst_path}")
+        # logger.info(f"linking {base_path} to {dst_path}")
         # shell scripts might change files as side effect hence we copy all files
         # instead of linking to avoid side effects in future it might make sense to
         # specify the files which are modified in the yaml file
@@ -243,7 +238,7 @@ def initialize_if_required(job: Job) -> bool:
         _link_path(base_path, dst_path, parent_id, copy_instead_link)
         job.doc["state"]["is_initialized"] = True
         if GLOBAL_UNINIT_COUNT:
-            logging.info(
+            logger.info(
                 "Done initialization of case"
                 f" {job.id} [{GLOBAL_INIT_COUNT}/{int(GLOBAL_UNINIT_COUNT)}]\r"
             )
@@ -286,8 +281,8 @@ def execute_operation(job: Job, operation_name: str, operations) -> Literal[True
                 getattr(sys.modules[__name__], func)(job, operation.get(func))
         except Exception as e:
             tb = traceback.format_exc()
-            logging.info(tb)
-            logging.error(e)
+            logger.info(tb)
+            logger.error(e)
             job.doc["state"]["global"] == "failure"
     return True
 
@@ -398,7 +393,8 @@ def MultiCase(job: Job, args={}):
             "Please specify a type for the MultiCase. Valid types: GitRepo, CaseOnDisk,"
             " OpenFOAMTutorialCase"
         )
-    instantiate_origin_class(args["type"], args).init(job.path)
+    if not (Path(job.path) / "case").exists():
+        instantiate_origin_class(args["type"], args).init(job.path)
 
 
 @generate
@@ -652,7 +648,7 @@ def run_cmd_builder(job: Job, cmd_format: str, args: dict) -> str:
 
     skip_complete = os.environ.get("OBR_SKIP_COMPLETE")
     if skip_complete and finished(job):
-        logging.info(f"Skipping Job {job.id} since it is completed.")
+        logger.info(f"Skipping Job {job.id} since it is completed.")
         return "true"
 
     case = OpenFOAMCase(str(job.path) + "/case", job)

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -28,6 +28,7 @@ class OpenFOAMProject(flow.FlowProject):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+
     def print_operations(self):
         ops = sorted(self.groups.keys())
         logger.info("Available operations are:\n\t" + "\n\t".join(ops))

--- a/src/obr/signac_wrapper/operations.py
+++ b/src/obr/signac_wrapper/operations.py
@@ -22,12 +22,12 @@ from obr.core.caseOrigins import instantiate_origin_class
 
 logger = logging.getLogger("OBR")
 
+
 class OpenFOAMProject(flow.FlowProject):
     filtered_jobs: list[Job] = []
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
 
     def print_operations(self):
         ops = sorted(self.groups.keys())

--- a/src/obr/signac_wrapper/submit.py
+++ b/src/obr/signac_wrapper/submit.py
@@ -109,4 +109,4 @@ def submit_impl(
             **cluster_args,
         )
         logger.info(ret_submit)
-    logger.success("Successfully submited")
+    logger.success("Successfully submitted")

--- a/src/obr/signac_wrapper/submit.py
+++ b/src/obr/signac_wrapper/submit.py
@@ -1,6 +1,5 @@
 import shutil
 import os
-import logging
 
 from pathlib import Path
 from signac.job import Job
@@ -9,6 +8,7 @@ from tqdm import tqdm
 
 from .operations import OpenFOAMProject, basic_eligible
 from .labels import final
+from ..core.logger_setup import logger
 
 
 def submit_impl(
@@ -61,7 +61,7 @@ def submit_impl(
             selected_jobs: list[Job] = [
                 j for j in project if bundle_value in list(j.sp().values())
             ]
-            logging.info(f"Submit bundle {bundle_value} of {len(eligible_jobs)} jobs")
+            logger.info(f"Submit bundle {bundle_value} of {len(eligible_jobs)} jobs")
             ret_submit = (
                 project.submit(
                     jobs=selected_jobs,
@@ -71,7 +71,7 @@ def submit_impl(
                 )
                 or ""
             )
-            logging.info("Submission response" + str(ret_submit))
+            logger.info("Submission response" + str(ret_submit))
             time.sleep(15)
     else:
         eligible_jobs = []
@@ -81,12 +81,12 @@ def submit_impl(
                     if final(job):
                         eligible_jobs.append(job)
             else:
-                logging.info(f"Collecting eligible jobs for operation: {operation}.")
+                logger.info(f"Collecting eligible jobs for operation: {operation}.")
                 for job in tqdm(jobs):
                     if basic_eligible(job, operation):
                         eligible_jobs.append(job)
 
-        logging.info(
+        logger.info(
             f"Submitting operations {operations}. In total {len(eligible_jobs)} of"
             f" {len(jobs)} individual jobs.\nEligible jobs"
             f" {[j.id for j in eligible_jobs]}"
@@ -94,7 +94,7 @@ def submit_impl(
 
         bundle_size = 1
         if len(eligible_jobs) > max_queue_size:
-            logging.warning(
+            logger.warning(
                 "Found more eligible jobs than maximum allowed queue size of"
                 f" {max_queue_size}. Bundling jobs together. This might fail if jobs"
                 " request different resources. For more fine grained control use"
@@ -108,4 +108,5 @@ def submit_impl(
             bundle_size=bundle_size,
             **cluster_args,
         )
-        logging.info(ret_submit)
+        logger.info(ret_submit)
+    logger.success("Successfully submited")


### PR DESCRIPTION
This PR improves our logging output. The following changes have been implemented:

- We now do a two fold approach to logging. First, simple colored terminal outputs for basic INFO and above levels. Second, detailed logs are written to `.obr/log`
- move from logging to obr specific logger
- add some success statements
- Suppress external log messages
